### PR TITLE
Allow `appBuild = 0`

### DIFF
--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -280,7 +280,6 @@ function nrAddAttributes(ev as Object) as Object
     ev.AddReplace("appDevId", app.GetDevID())
     ev.AddReplace("appIsDev", app.IsDev())
     appbuild = app.GetValue("build_version").ToInt()
-    if appbuild = 0 then appbuild = 1
     ev.AddReplace("appBuild", appbuild)
     'Uptime
     ev.AddReplace("uptime", Uptime(0))


### PR DESCRIPTION
we've just noticed that we can't separate version 1.4 build 0 and version 1.4 build 1 as they both populate `appBuild=1`