### PR TITLE
Add NewRelicVideoStop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file.
 
+## [1.0.9] - 2021/03/04
+### Change
+- Added NewRelicVideoStop function. In case the scene changes from the one containing a video player to another without it.
+
 ## [1.0.8] - 2021/02/10
 ### Change
 - Improved how the events are sent to New Relic. Now are sent in batches, instead of one by one.

--- a/README.md
+++ b/README.md
@@ -230,6 +230,25 @@ Example:
 	NewRelicVideoStart(m.nr, m.video)
 ```
 
+**NewRelicVideoStop**
+
+```
+NewRelicVideoStop(nr as Object) as Void
+
+Description:
+	Stop video logging.
+
+Arguments:
+	nr: New Relic Agent object.
+	
+Return:
+	Nothing.
+	
+Example:
+
+	NewRelicVideoStop(m.nr)
+```
+
 **nrProcessMessage**
 
 ```

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -75,17 +75,24 @@ function NewRelicVideoStart(videoObject as Object) as Void
     m.nrNumberOfErrors = 0
     
     'Setup event listeners 
-    videoObject.observeField("state", "nrStateObserver")
-    videoObject.observeField("contentIndex", "nrIndexObserver")
+    m.nrVideoObject.observeFieldScoped("state", "nrStateObserver")
+    m.nrVideoObject.observeFieldScoped("contentIndex", "nrIndexObserver")
     'Init heartbeat timer
     m.hbTimer = CreateObject("roSGNode", "Timer")
     m.hbTimer.repeat = true
     m.hbTimer.duration = 30
-    m.hbTimer.observeField("fire", "nrHeartbeatHandler")
+    m.hbTimer.observeFieldScoped("fire", "nrHeartbeatHandler")
     m.hbTimer.control = "start"
     
     'Player Ready
     nrSendPlayerReady()
+end function
+
+function NewRelicVideoStop() as Void
+    m.nrVideoObject.unobserveFieldScoped("state")
+    m.nrVideoObject.unobserveFieldScoped("contentIndex")
+    m.nrVideoObject = Invalid
+    m.hbTimer.control = "stop"
 end function
 
 function nrAppStarted(aa as Object) as Void

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -89,9 +89,11 @@ function NewRelicVideoStart(videoObject as Object) as Void
 end function
 
 function NewRelicVideoStop() as Void
+    ' Remove event listeners
     m.nrVideoObject.unobserveFieldScoped("state")
     m.nrVideoObject.unobserveFieldScoped("contentIndex")
     m.nrVideoObject = Invalid
+    ' Stop heartbeat timer
     m.hbTimer.control = "stop"
 end function
 

--- a/components/NewRelicAgent/NRAgent.xml
+++ b/components/NewRelicAgent/NRAgent.xml
@@ -13,10 +13,11 @@
 
 	<interface>
 		<!-- Properties -->
-		<field id="version" type="string" value="1.0.8"/>
+		<field id="version" type="string" value="1.0.9"/>
 		<!-- Public Methods (wrapped) -->
         <function name="NewRelicInit"/>
         <function name="NewRelicVideoStart"/>
+        <function name="NewRelicVideoStop"/>
         <function name="nrSceneLoaded"/>
         <function name="nrAppStarted"/>
         <function name="nrSendCustomEvent"/>

--- a/source/NewRelicAgent.brs
+++ b/source/NewRelicAgent.brs
@@ -41,6 +41,13 @@ function NewRelicVideoStart(nr as Object, video as Object) as Void
     nr.callFunc("NewRelicVideoStart", video)
 end function
 
+' Stop video logging.
+'
+' @param nr New Relic Agent object.
+function NewRelicVideoStop(nr as Object) as Void
+    nr.callFunc("NewRelicVideoStop")
+end function
+
 ' Check for a system log message, process it and sends the appropriate event. 
 '
 ' @param nr New Relic Agent object.


### PR DESCRIPTION
Related Issue:
https://github.com/newrelic/video-agent-roku/issues/20

This will allow destroying the video component when we switch the scene to the one that does not contain a video player.