### PR TITLE
Capture `Video.licenseStatus`

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ This event groups all actions related to video tracking.
 | `CONTENT_BUFFER_END` | Video ended buffering. |
 | `CONTENT_ERROR` | Video error happened. |
 | `CONTENT_HEARTBEAT` | Sent every 30 seconds between video start and video end. |
+| `LICENSE_STATUS` | Video has received a DRM license response |
 
 #### 2.2 Attributes
 
@@ -691,10 +692,10 @@ For video events, the common attributes include all `RokuSystem` common attribut
 | `errorInfoCode` | Property `error_code` from Video object errorInfo. | `CONTENT_ERROR` |
 | `errorDebugMsg` | Property `dbgmsg` from Video object errorInfo. | `CONTENT_ERROR` |
 | `errorAttributes` | Property `error_attributes` from Video object errorInfo. | `CONTENT_ERROR` |
-| `licenseStatusDuration` | Property `duration` from Video object licenseStatus. | `CONTENT_ERROR` |
-| `licenseStatusKeySystem` | Property `keySystem` from Video object licenseStatus. | `CONTENT_ERROR` |
-| `licenseStatusResponse` | Property `response` from Video object licenseStatus. | `CONTENT_ERROR` |
-| `licenseStatusStatus` | Property `status` from Video object licenseStatus. | `CONTENT_ERROR` |
+| `licenseStatusDuration` | Property `duration` from Video object licenseStatus. | `CONTENT_ERROR`, `LICENSE_STATUS` |
+| `licenseStatusKeySystem` | Property `keySystem` from Video object licenseStatus. | `CONTENT_ERROR`, `LICENSE_STATUS` |
+| `licenseStatusResponse` | Property `response` from Video object licenseStatus. | `CONTENT_ERROR`, `LICENSE_STATUS` |
+| `licenseStatusStatus` | Property `status` from Video object licenseStatus. | `CONTENT_ERROR`, `LICENSE_STATUS` |
 | `isInitialBuffering` | Is the initial buffering event, and not a rebuffering. In playlists it only happens at the beginning, and not on every video. | `CONTENT_BUFFER_*` |
 
 <a name="open-source"/>

--- a/README.md
+++ b/README.md
@@ -691,6 +691,10 @@ For video events, the common attributes include all `RokuSystem` common attribut
 | `errorInfoCode` | Property `error_code` from Video object errorInfo. | `CONTENT_ERROR` |
 | `errorDebugMsg` | Property `dbgmsg` from Video object errorInfo. | `CONTENT_ERROR` |
 | `errorAttributes` | Property `error_attributes` from Video object errorInfo. | `CONTENT_ERROR` |
+| `licenseStatusDuration` | Property `duration` from Video object licenseStatus. | `CONTENT_ERROR` |
+| `licenseStatusKeySystem` | Property `keySystem` from Video object licenseStatus. | `CONTENT_ERROR` |
+| `licenseStatusResponse` | Property `response` from Video object licenseStatus. | `CONTENT_ERROR` |
+| `licenseStatusStatus` | Property `status` from Video object licenseStatus. | `CONTENT_ERROR` |
 | `isInitialBuffering` | Is the initial buffering event, and not a rebuffering. In playlists it only happens at the beginning, and not on every video. | `CONTENT_BUFFER_*` |
 
 <a name="open-source"/>

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -77,6 +77,7 @@ function NewRelicVideoStart(videoObject as Object) as Void
     'Setup event listeners 
     m.nrVideoObject.observeFieldScoped("state", "nrStateObserver")
     m.nrVideoObject.observeFieldScoped("contentIndex", "nrIndexObserver")
+    m.nrvideoObject.observeFieldScoped("licenseStatus", "nrLicenseStatusObserver")
     'Init heartbeat timer
     m.hbTimer = CreateObject("roSGNode", "Timer")
     m.hbTimer.repeat = true
@@ -868,6 +869,17 @@ function nrIndexObserver() as Void
     m.nrVideoCounter = m.nrVideoCounter + 1
     nrSendRequest()
     nrSendStart()
+end function
+
+function nrLicenseStatusObserver(event as Object) as Void
+    licenseStatus = event.getData()
+    attr = {
+        "licenseStatusDuration": licenseStatus.duration,
+        "licenseStatusKeySystem": licenseStatus.keySystem,
+        "licenseStatusResponse": licenseStatus.response,
+        "licenseStatusStatus": licenseStatus.status
+    }
+    nrSendVideoEvent("LICENSE_STATUS", attr)
 end function
 
 function nrHeartbeatHandler() as Void

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -522,6 +522,12 @@ function nrSendError(video as Object) as Void
             "errorAttributes": video.errorInfo.error_attributes
         })
     end if
+    if video.licenseStatus <> Invalid
+        attr.append({
+            "licenseStatus": formatJson(video.licenseStatus)
+        })
+    end if
+
     nrSendVideoEvent(nrAction("ERROR"), attr)
 end function
 

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -524,7 +524,10 @@ function nrSendError(video as Object) as Void
     end if
     if video.licenseStatus <> Invalid
         attr.append({
-            "licenseStatus": formatJson(video.licenseStatus)
+            "licenseStatusDuration": video.licenseStatus.duration,
+            "licenseStatusKeySystem": video.licenseStatus.keySystem,
+            "licenseStatusResponse": video.licenseStatus.response,
+            "licenseStatusStatus": video.licenseStatus.status
         })
     end if
 

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -524,12 +524,7 @@ function nrSendError(video as Object) as Void
         })
     end if
     if video.licenseStatus <> Invalid
-        attr.append({
-            "licenseStatusDuration": video.licenseStatus.duration,
-            "licenseStatusKeySystem": video.licenseStatus.keySystem,
-            "licenseStatusResponse": video.licenseStatus.response,
-            "licenseStatusStatus": video.licenseStatus.status
-        })
+        attr.append(getLicenseStatusAttributes(video.licenseStatus))
     end if
 
     nrSendVideoEvent(nrAction("ERROR"), attr)
@@ -873,13 +868,17 @@ end function
 
 function nrLicenseStatusObserver(event as Object) as Void
     licenseStatus = event.getData()
-    attr = {
+    attr = getLicenseStatusAttributes(licenseStatus)
+    nrSendVideoEvent("LICENSE_STATUS", attr)
+end function
+
+function getLicenseStatusAttributes(licenseStatus as Object) as object
+    return {
         "licenseStatusDuration": licenseStatus.duration,
         "licenseStatusKeySystem": licenseStatus.keySystem,
         "licenseStatusResponse": licenseStatus.response,
         "licenseStatusStatus": licenseStatus.status
     }
-    nrSendVideoEvent("LICENSE_STATUS", attr)
 end function
 
 function nrHeartbeatHandler() as Void


### PR DESCRIPTION
This is an undocumented field that provides the DRM license response. I find it incredibly valuable to capture.
```
onLicenseStatusChanged() |video.licenseStatus=<Component: roAssociativeArray> =
{
    duration: 0
    keysystem: "Widevine"
    response: "{"code":130001,"message":"License denied. There were no valid internal or external entitlements for the user: [__anonymous]"}"
    status: 403
}
```