### PR TITLE
ifDeviceInfo.GetVersion() superseded by ifDeviceInfo.GetOsVersion()

### DIFF
--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -864,7 +864,7 @@ function nrTimestamp() as LongInteger
 end function
 
 function nrGetOSVersion(dev as Object) as Object
-    if findMemberFunction(dev, "GetOSVersion") <> Invalid
+    if FindMemberFunction(dev, "GetOSVersion") <> Invalid
         verDict = dev.GetOsVersion()
         return {version: verDict.major + "." + verDict.minor + "." + verDict.revision, build: verDict.build}
     else

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -864,13 +864,11 @@ function nrTimestamp() as LongInteger
 end function
 
 function nrGetOSVersion(dev as Object) as Object
-    verStr = dev.GetVersion()
-    if verStr = "999.99E99999X"
-        'RokuOS 10
-        verDict = dev.GetOSVersion()
+    if findMemberFunction(dev, "GetOSVersion") <> Invalid
+        verDict = dev.GetOsVersion()
         return {version: verDict.major + "." + verDict.minor + "." + verDict.revision, build: verDict.build}
     else
-        'Older than RokuOS 10
+        verStr = dev.GetVersion()
         return {version: verStr.Mid(2, 3) + "." + verStr.Mid(5, 1), build: verStr.Mid(8, 4)}
     end if
 end function


### PR DESCRIPTION
Here in Australia `ifDeviceInfo.getVersion()` returns `999.99E99999A` and fails the comparison with `999.99E99999X`.
This solution should cater for all.