### PR TITLE
Added network proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file.
 
+## [1.3.4] - 2021/11/09
+### Add
+- added network proxy support
+
 ## [1.3.4] - 2021/08/02
 ### Fix
 - Fix hbTimer callback attachment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file.
 
-## [1.3.4] - 2021/11/09
+## [1.4.0] - 2021/11/09
 ### Add
 - added network proxy support
 

--- a/README.md
+++ b/README.md
@@ -517,6 +517,26 @@ Example:
 	nrForceHarvest(m.nr)
 ```
 
+**nrUpdateConfig**
+
+```
+nrUpdateConfig(nr as Object, config as Object) as Void
+
+Description:
+	Updates configuration, such as network proxy URL.
+
+Arguments:
+	nr: New Relic Agent object
+	config: configuration object
+
+Return:
+	Nothing
+
+Example:
+	config = { networkProxy: "http://example.com:8888/;" }
+	nrUpdateConig(m.nr, config)
+```
+
 <a name="data-model"></a>
 
 ### Data Model
@@ -850,6 +870,9 @@ curl -d '' 'http://ROKU_IP:8060/launch/dev?RunTests=true'
 ```
 
 Where `ROKU_IP` is the address of the Roku device where the channel is installed. Connect to the debug terminal (port 8085) to see test results.
+
+### Debugging
+Network proxying is supported using URL re-write (see [App Level Proxying](https://rokulikeahurricane.io/proxying_network_requests)). To send all network requests via a proxy call `nrUpdateConfig()` function with the `proxyUrl` parameter object property. Be sure to specify the same URL delimiter as your proxy re-write rule.
 
 <a name="open-source"></a>
 

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -8,6 +8,7 @@
 sub init()
     m.nrLogsState = false
     m.nrAgentVersion = m.top.version
+    m.serviceUrl = ""
     print "************************************************************"
     print "   New Relic Agent for Roku v" + m.nrAgentVersion
     print "   Copyright 2019-2021 New Relic Inc. All Rights Reserved."
@@ -40,9 +41,10 @@ function NewRelicInit(account as String, apikey as String) as Void
 
     'Create and configure NRTask
     m.bgTask = m.top.findNode("NRTask")
-    m.bgTask.setField("accountNumber", m.nrAccountNumber)
+    m.serviceUrl = box("https://insights-collector.newrelic.com/v1/accounts/" + account + "/events")
+    m.bgTask.setField("serviceUrl", m.serviceUrl)
     m.bgTask.setField("apiKey", m.nrInsightsApiKey)
-    
+
     'Init harvest timer
     m.nrHarvestTimer = m.top.findNode("nrHarvestTimer")
     m.nrHarvestTimer.ObserveField("fire", "nrHarvestTimerHandler")
@@ -107,6 +109,12 @@ function NewRelicVideoStop() as Void
         m.hbTimer.unobserveFieldScoped("fire")
         m.hbTimer.control = "stop"
     end if
+end function
+
+' modifies current configuration
+function UpdateConfig(config as object) as void
+    if config = invalid then return
+    if config.proxyUrl <> invalid then m.bgTask.setField("serviceUrl", config.proxyUrl + m.serviceUrl)
 end function
 
 function nrAppStarted(aa as Object) as Void

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -112,7 +112,7 @@ function NewRelicVideoStop() as Void
 end function
 
 ' modifies current configuration
-function UpdateConfig(config as object) as void
+function nrUpdateConfig(config as object) as void
     if config = invalid then return
     if config.proxyUrl <> invalid then m.bgTask.setField("serviceUrl", config.proxyUrl + m.serviceUrl)
 end function

--- a/components/NewRelicAgent/NRAgent.xml
+++ b/components/NewRelicAgent/NRAgent.xml
@@ -18,7 +18,7 @@
         <function name="NewRelicInit"/>
         <function name="NewRelicVideoStart"/>
         <function name="NewRelicVideoStop"/>
-        <function name="UpdateConfig"/>
+        <function name="nrUpdateConfig"/>
         <function name="nrSceneLoaded"/>
         <function name="nrAppStarted"/>
         <function name="nrSendCustomEvent"/>

--- a/components/NewRelicAgent/NRAgent.xml
+++ b/components/NewRelicAgent/NRAgent.xml
@@ -13,7 +13,7 @@
 
 	<interface>
 		<!-- Properties -->
-		<field id="version" type="string" value="1.3.4"/>
+		<field id="version" type="string" value="1.4.0"/>
 		<!-- Public Methods (wrapped) -->
         <function name="NewRelicInit"/>
         <function name="NewRelicVideoStart"/>

--- a/components/NewRelicAgent/NRAgent.xml
+++ b/components/NewRelicAgent/NRAgent.xml
@@ -18,6 +18,7 @@
         <function name="NewRelicInit"/>
         <function name="NewRelicVideoStart"/>
         <function name="NewRelicVideoStop"/>
+        <function name="UpdateConfig"/>
         <function name="nrSceneLoaded"/>
         <function name="nrAppStarted"/>
         <function name="nrSendCustomEvent"/>
@@ -37,9 +38,9 @@
         <function name="nrProcessSystemEvent"/>
         <function name="nrAddToTotalAdPlaytime"/>
     </interface>
-    
+
 	<script type="text/brightscript" uri="NRAgent.brs"/>
-	
+
 	<children>
         <Timer id="nrHeartbeatTimer" repeat="true" duration="30"/>
 		<Timer id="nrHarvestTimer" repeat="true" duration="10"/>

--- a/components/NewRelicAgent/NRTask.brs
+++ b/components/NewRelicAgent/NRTask.brs
@@ -10,13 +10,12 @@ sub init()
 end sub
 
 function nrInsertInsightsEvents(events as Object) as Object
-    url = box("https://insights-collector.newrelic.com/v1/accounts/" + m.accountNumber + "/events")
     jsonString = FormatJson(events)
 
     rport = CreateObject("roMessagePort")
     urlReq = CreateObject("roUrlTransfer")
 
-    urlReq.SetUrl(url)
+    urlReq.SetUrl(m.serviceUrl)
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)
@@ -57,7 +56,7 @@ function nrTaskMain() as Void
     if m.nr = invalid
         m.nr = m.top.getParent()
         m.apiKey = m.top.apiKey
-        m.accountNumber = m.top.accountNumber
+        m.serviceUrl = m.top.serviceUrl
     end if
     nrEventProcessor()
     'print "---- Ended running NRTask ----"

--- a/components/NewRelicAgent/NRTask.xml
+++ b/components/NewRelicAgent/NRTask.xml
@@ -12,7 +12,7 @@
 <component name="com.newrelic.NRTask" extends="Task" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://devtools.web.roku.com/schema/RokuSceneGraph.xsd">
 	<interface>
 		<!-- Properties -->
-		<field id="accountNumber" type="string" value=""/>
+		<field id="serviceUrl" type="string" value=""/>
 		<field id="apiKey" type="string" value=""/>
     </interface>
 

--- a/source/NewRelicAgent.brs
+++ b/source/NewRelicAgent.brs
@@ -81,6 +81,14 @@ function nrSetCustomAttributeList(nr as Object, attr as Object, actionName = "" 
     nr.callFunc("nrSetCustomAttributeList", attr, actionName)
 end function
 
+' modifies current configuration
+'
+' @param nr New Relic Agent object
+' @param obj { proxyUrl: string, delimited network proxy URL }
+function nrUpdateConfig(nr as object, config as object) as void
+    nr.callFunc("nrUpdateConfig", config)
+end function
+
 ' Send an APP_STARTED event of type RokuSystem.
 '
 ' @param nr New Relic Agent object.


### PR DESCRIPTION
This PR adds network proxy support as described in https://rokulikeahurricane.io/proxying_network_requests `App-level proxying` - this is the most common type of proxy for development of Roku channels. Default behavior is unchanged, proxy can be added using `UpdateConfig` method.