### PR TITLE
Option to use custom timestamp if provided to nrSendHTTPRequest and nrSendHTTPResponse

### DIFF
--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -265,12 +265,19 @@ function nrSendHttpRequest(attr as Object) as Void
     domain = nrExtractDomainFromUrl(attr["origUrl"])
     attr["domain"] = domain
     transId = stri(attr["transferIdentity"])
-    m.nrRequestIdentifiers[transId] = nrTimestamp()
+    timestamp = 0
+    'Use custom timestamp if included within the attr
+    if attr.timestamp <> invalid AND type(attr["timestamp"]) = "LongInteger"
+        timestamp = attr["timestamp"]
+    else
+        timestamp = nrTimestamp()
+    end if
+    m.nrRequestIdentifiers[transId] = timestamp
     'Clean up old transfers
     toDeleteKeys = []
     for each item in m.nrRequestIdentifiers.Items()
         'More than 10 minutes without a response, delete the request ID
-        if nrTimestamp() - item.value > 10*60*1000
+        if timestamp - item.value > 10*60*1000
             toDeleteKeys.Push(item.key)
         end if
     end for
@@ -293,8 +300,15 @@ function nrSendHttpResponse(attr as Object) as Void
     domain = nrExtractDomainFromUrl(attr["origUrl"])
     attr["domain"] = domain
     transId = stri(attr["transferIdentity"])
+    timestamp = 0
+    'Use custom timestamp if included within the attr
+    if attr.timestamp <> invalid AND type(attr["timestamp"]) = "LongInteger"
+        timestamp = attr["timestamp"]
+    else
+        timestamp = nrTimestamp()
+    end if
     if m.nrRequestIdentifiers[transId] <> invalid
-        deltaMs = nrTimestamp() - m.nrRequestIdentifiers[transId]
+        deltaMs = timestamp - m.nrRequestIdentifiers[transId]
         attr["timeSinceHttpRequest"] = deltaMs
         m.nrRequestIdentifiers.Delete(transId)
         'Generate metrics

--- a/source/NewRelicAgent.brs
+++ b/source/NewRelicAgent.brs
@@ -155,12 +155,13 @@ end function
 '
 ' @param nr New Relic Agent object.
 ' @param urlReq URL request, roUrlTransfer object.
-function nrSendHttpRequest(nr as Object, urlReq as Object) as Void
+function nrSendHttpRequest(nr as Object, urlReq as Object, timestamp = invalid) as Void
     if type(urlReq) = "roUrlTransfer"
         attr = {
             "origUrl": urlReq.GetUrl(),
             "transferIdentity": urlReq.GetIdentity(),
             "method": urlReq.GetRequest()
+            "timestamp": timestamp
         }
         nr.callFunc("nrSendHttpRequest", attr)
     end if
@@ -171,7 +172,7 @@ end function
 ' @param nr New Relic Agent object.
 ' @param _url Request URL.
 ' @param msg A message of type roUrlEvent.
-function nrSendHttpResponse(nr as Object, _url as String, msg as Object) as Void
+function nrSendHttpResponse(nr as Object, _url as String, msg as Object, timestamp = invalid) as Void
     if type(msg) = "roUrlEvent"
         attr = {
             "origUrl": _url
@@ -180,6 +181,7 @@ function nrSendHttpResponse(nr as Object, _url as String, msg as Object) as Void
         attr.AddReplace("httpCode", msg.GetResponseCode())
         attr.AddReplace("httpResult", msg.GetFailureReason())
         attr.AddReplace("transferIdentity", msg.GetSourceIdentity())
+        attr.AddReplace("timestamp", timestamp)
         
         header = msg.GetResponseHeaders()
         


### PR DESCRIPTION
Problem
The client application is not able to send a custom timestamp of the captured http events if sent to the New Relic agent at a later stage. Use cases such as holding on to these events and sending them later provides inaccurate timestamps and ```timeSinceHttpRequest```  since we can defer the request and send them at the same time as the response, Another use is deferring these events during the app boot process or conditionally holding and dropping specific http events when sampling.

Solution
Added the option to check if ```timestamp property``` is included within the ```attr``` and to simply use this, otherwise, use the ```nrTimestamp``` within the agent.