### PR TITLE
Flag-to-track-video-resume-as-CONTENT-START

### DIFF
--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -140,6 +140,9 @@ function NewRelicInit(account as String, apikey as String, region as String) as 
     nrResetRAFTimers()
     nrResetRAFState()
 
+    'Init flag to track CONTENT_START event for video resume
+    m.nrShouldTrackResumeAsContentStart = false
+
     m.enableMemMonitor = false
     if isMemoryMonitorAvailable(CreateObject("roDeviceInfo").GetModel())
         'Available since v10.5
@@ -556,6 +559,14 @@ function nrSendSummaryMetric(name as String, interval as Integer, value as Objec
 
     m.nrMetricArrayIndex = nrAddSample(metric, m.nrMetricArray, m.nrMetricArrayIndex, m.nrMetricArrayK)
 end function
+
+function nrEnableTrackResumeAsContentStart() as Void
+    m.nrShouldTrackResumeAsContentStart = true
+  end function
+  
+  function nrDisableTrackResumeAsContentStart() as Void
+    m.nrShouldTrackResumeAsContentStart = false
+  end function
 
 '=========================='
 ' Public Internal Functions '
@@ -1427,7 +1438,7 @@ function nrStateTransitionPlaying() as Void
         shouldSendStart = m.nrIsInitialBuffering
         nrSendBufferEnd()
         
-        if m.nrVideoObject.position = 0
+        if m.nrVideoObject.position = 0 or m.nrShouldTrackResumeAsContentStart
             if lastSrc = currentSrc OR m.nrVideoObject.contentIsPlaylist = false
                 'Send Start only if initial start not sent already
                 if shouldSendStart then nrSendStart()

--- a/components/NewRelicAgent/NRAgent.xml
+++ b/components/NewRelicAgent/NRAgent.xml
@@ -44,6 +44,8 @@
         <function name="nrSendMetric"/>
         <function name="nrSendCountMetric"/>
         <function name="nrSendSummaryMetric"/>
+        <function name="nrEnableTrackResumeAsContentStart"/>
+        <function name="nrDisableTrackResumeAsContentStart"/>
         <!-- Internal Methods (not wrapped, but used from the outside by some internal components) -->
         <function name="nrActivateLogging"/>
         <function name="nrCheckLoggingState"/>

--- a/source/NewRelicAgent.brs
+++ b/source/NewRelicAgent.brs
@@ -327,3 +327,17 @@ function nrSendSummaryMetric(nr as Object, name as String, interval as Integer, 
     }
     nr.callFunc("nrSendSummaryMetric", name, interval, value, attr)
 end function
+
+' Enable shouldTrackResumeAsContentStart flag
+'
+' @param nr New Relic Agent object.
+function nrEnableTrackResumeAsContentStart(nr as Object) as Void
+    nr.callFunc("nrEnableTrackResumeAsContentStart")
+end function
+  
+' Disable shouldTrackResumeAsContentStart flag
+'
+' @param nr New Relic Agent object.
+function nrDisableTrackResumeAsContentStart(nr as Object) as Void
+    nr.callFunc("nrDisableTrackResumeAsContentStart")
+end function


### PR DESCRIPTION
**Issue Description:** 
Our App has a feature to let user play content from a resume position. We noticed below issue in New Relic reporting when playback initiated using Resume button.

Given: User initiated payback using Resume CTA.

When: videoNode sent to New Relic has videoNode.position > 0

Then: CONTENT_START action not triggered.

Then: Our reports would miss all playbacks initiated through Resume CTA. 

**Fix:** 
To fix the above issue, i have added a flag called m.nrShouldTrackResumeAsContentStart, which can be set by the App.
If this flag is set to true, app will trigger CONTENT_START action even if videoNode.position > 0. If will only check if the state changed to `playing` after initial buffer to trigger the CONTENT_START action. 