### PR TITLE
Multiple Fixes and Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file.
 
+## [3.2.5] - 2024/07/16
+### Add
+- Instrument attributes for metrics and logs.
+### Fix
+- Allow overwriting custom attributes.
+- Send `CONTENT_START` when resuming a video.
+
 ## [3.2.4] - 2024/01/10
 ### Add
 - Memory attributes.

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -1434,11 +1434,9 @@ function nrStateTransitionPlaying() as Void
         shouldSendStart = m.nrIsInitialBuffering
         nrSendBufferEnd()
         
-        if m.nrVideoObject.position = 0
-            if lastSrc = currentSrc OR m.nrVideoObject.contentIsPlaylist = false
-                'Send Start only if initial start not sent already
-                if shouldSendStart then nrSendStart()
-            end if
+        if lastSrc = currentSrc OR m.nrVideoObject.contentIsPlaylist = false
+            'Send Start only if initial start not sent already
+            if shouldSendStart then nrSendStart()
         end if
     end if
 end function

--- a/components/NewRelicAgent/NRAgent.xml
+++ b/components/NewRelicAgent/NRAgent.xml
@@ -13,7 +13,7 @@
 
 	<interface>
 		<!-- Properties -->
-		<field id="version" type="string" value="3.2.4"/>
+		<field id="version" type="string" value="3.2.5"/>
 		<!-- Public Methods (wrapped) -->
         <function name="NewRelicInit"/>
         <function name="NewRelicVideoStart"/>

--- a/components/NewRelicAgent/NRTask.brs
+++ b/components/NewRelicAgent/NRTask.brs
@@ -11,12 +11,28 @@ sub init()
 end sub
 
 function nrPushSamples(samples as Object, endpoint as String, sampleType as String) as Object
-    'Metric API requires a specific format
+    'Common attributes, only used with Metric and Log API. Event API uses a different format, without a common object, and these
+    'properties are inserted in every event.
+    commonObject = {
+        "attributes": {
+            "instrumentation.provider": "media",
+            "instrumentation.name": "roku",
+            "instrumentation.version": m.top.getParent().version
+        }
+    }
+    'Use a different format for Metric API and Log API
     if sampleType = "metric"
         metricsModel = [{
-            "metrics": samples
+            "metrics": samples,
+            "common": commonObject,
         }]
         samples = metricsModel
+    else if sampleType = "log"
+        logsModel = [{
+            "logs": samples,
+            "common": commonObject,
+        }]
+        samples = logsModel
     end if
 
     jsonString = FormatJson(samples)


### PR DESCRIPTION
- Add `instrumentation.*` attributes to Metrics and Logs (https://github.com/newrelic/video-agent-roku/issues/65).
- Fix `contentId` problems (https://github.com/newrelic/video-agent-roku/issues/66).
- Fix `CONTENT_START` not sent when video is resumed (https://github.com/newrelic/video-agent-roku/pull/69).