### PR TITLE
fix: Add obfuscation rules support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Will result in something like the following:
 - [Usage](#usage)
 - [Agent API](#api)
 - [Quality of Experience (QOE) Tracking](#qoe-tracking)
+- [Obfuscation Rules](#obfuscation-rules)
 - [Data Model](#data-model)
 - [Ad Tracking](#ad-track)
 - [Testing](#testing)
@@ -722,6 +723,34 @@ Example:
 	nrDelDomainSubstitution(nr, "^.+\.my\.domain\.com$")
 ```
 
+**nrSetObfuscationRules**
+
+```
+nrSetObfuscationRules(nr as Object, rules as Object) as Void
+
+Description:
+	Set obfuscation rules to mask sensitive data in all outgoing events before they are
+	buffered. Rules apply to all event types: VideoAction (including QOE_AGGREGATE),
+	VideoErrorAction, VideoAdAction (RAF and IMA), VideoCustomAction, and
+	ConnectedDeviceSystem. Only string attribute values are processed; numeric and boolean
+	values are passed through unchanged. Rules are applied in array order. Call with an
+	empty array to remove all rules.
+
+Arguments:
+	nr: New Relic Agent object.
+	rules: Array of { regex: String, replacement: String } objects.
+
+Return:
+	Nothing
+
+Example:
+	nrSetObfuscationRules(m.nr, [
+		{ regex: "account-[0-9]+",  replacement: "ACCOUNT_ID" },
+		{ regex: "token=[^&]+",     replacement: "token=REDACTED" },
+		{ regex: "/users/[^/]+",    replacement: "/users/USER_ID" }
+	])
+```
+
 **nrSendLog**
 
 ```
@@ -883,6 +912,59 @@ With the default event harvest interval of `60` seconds:
 - Ad breaks are excluded from QOE calculations to provide accurate content quality metrics
 - When QOE tracking is disabled, no QOE_AGGREGATE events are sent
 
+
+<a name="obfuscation-rules"></a>
+
+### Obfuscation Rules
+
+The agent can be configured with regex-based obfuscation rules to mask sensitive data before events are sent to New Relic. This is useful when fields like `contentSrc`, `contentTitle`, `origUrl`, or custom attributes may inadvertently contain user IDs, tokens, or other PII.
+
+Rules are applied to every string attribute in every outgoing event — including video, ad (RAF and IMA), QOE, system, and custom events — before the event enters the internal buffer.
+
+#### Configuration
+
+Call `nrSetObfuscationRules` after creating the agent. Each rule is an associative array with a `regex` string and a `replacement` string:
+
+```brightscript
+m.nr = NewRelic("ACCOUNT_ID", "API_KEY", "APP_NAME", "APP_TOKEN")
+
+nrSetObfuscationRules(m.nr, [
+    { regex: "account-[0-9]+",  replacement: "ACCOUNT_ID" },
+    { regex: "token=[^&]+",     replacement: "token=REDACTED" },
+    { regex: "/users/[^/]+",    replacement: "/users/USER_ID" }
+])
+```
+
+To remove all rules at runtime, call with an empty array:
+
+```brightscript
+nrSetObfuscationRules(m.nr, [])
+```
+
+#### Rule Ordering
+
+Rules are applied in the order they appear in the array. The output of one rule is the input to the next. Order matters when patterns could overlap:
+
+```brightscript
+nrSetObfuscationRules(m.nr, [
+    ' Applied first — masks the specific token format
+    { regex: "auth-token-[a-z0-9]+", replacement: "AUTH_TOKEN" },
+    ' Applied second — masks any remaining bare token references
+    { regex: "token=[^&]+",          replacement: "token=REDACTED" }
+])
+```
+
+#### Behavior and Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| No rules configured | No-op; zero performance overhead |
+| Empty `replacement` string | Matched content is deleted from the value |
+| Invalid regex pattern | Rule is skipped; a warning is written to the agent log |
+| Non-string attribute values (numbers, booleans) | Passed through unchanged |
+| Replacing all rules | Call `nrSetObfuscationRules` again with the new array; previous rules are discarded |
+
+> **Note:** Roku uses `roRegex` for pattern matching. Complex lookahead/lookbehind assertions are not supported. Patterns that are valid in JavaScript or Java regex may need to be simplified for Roku.
 
 <a name="data-model"></a>
 

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -151,7 +151,10 @@ function NewRelicInit(account as String, apikey as String,appName as String, reg
 
     'Domain attribute matching patterns
     m.domainPatterns = CreateObject("roAssociativeArray")
-    
+
+    'Obfuscation rules
+    m.nrObfuscationRules = []
+
     'Ad tracker states
     m.rafState = CreateObject("roAssociativeArray")
     m.rafState.numberOfAds = 0
@@ -334,6 +337,44 @@ end function
 ' Delete a matching pattern created with nrAddDomainSubstitution
 function nrDelDomainSubstitution(pattern as String) as Void
     m.domainPatterns.Delete(pattern)
+end function
+
+' Set obfuscation rules to mask sensitive data in all outgoing events before buffering.
+' Rules are applied in order; each rule is a { regex: String, replacement: String } object.
+' Validates all rules immediately at registration time and rejects the entire set if any are invalid.
+function nrSetObfuscationRules(rules as Object) as Void
+    if type(rules) <> "roArray"
+        nrLog("nrSetObfuscationRules: rules must be an Array, ignoring.")
+        return
+    end if
+
+    validated = []
+    for each rule in rules
+        if type(rule) <> "roAssociativeArray"
+            nrLog(["nrSetObfuscationRules: invalid rule type, expected object"])
+            return
+        end if
+        regexVal = rule.regex
+        replacementVal = rule.replacement
+        if (type(regexVal) <> "String" and type(regexVal) <> "roString") or (type(replacementVal) <> "String" and type(replacementVal) <> "roString")
+            nrLog(["nrSetObfuscationRules: regex and replacement must be Strings"])
+            return
+        end if
+        regexStr = regexVal + ""
+        replacementStr = replacementVal + ""
+        if regexStr = ""
+            nrLog("nrSetObfuscationRules: regex cannot be empty")
+            return
+        end if
+        rx = CreateObject("roRegex", regexStr, "i")
+        if rx = invalid
+            nrLog(["nrSetObfuscationRules: invalid regex pattern:", regexStr])
+            return
+        end if
+        validated.Push({ pattern: regexStr, replacement: replacementStr })
+    end for
+
+    m.nrObfuscationRules = validated
 end function
 
 function nrAppStarted(aa as Object) as Void
@@ -916,8 +957,38 @@ function nrGetBackAllSamples(sampleType as String, samples as Object) as Void
     end if
 end function
 
+function nrApplyObfuscationToEvent(event as Object) as Void
+    if event = invalid then return
+    rules = m.nrObfuscationRules
+    if rules = invalid or rules.Count() = 0 then return
+
+    keys = []
+    for each key in event
+        keys.Push(key)
+    end for
+
+    for each key in keys
+        value = event[key]
+        if type(value) = "String" or type(value) = "roString"
+            newValue = value + ""
+            for each rule in rules
+                if rule.pattern <> invalid and rule.replacement <> invalid
+                    rx = CreateObject("roRegex", rule.pattern, "i")
+                    if rx <> invalid
+                        newValue = rx.ReplaceAll(newValue, rule.replacement)
+                    end if
+                end if
+            end for
+            if value <> newValue
+                event[key] = newValue
+            end if
+        end if
+    end for
+end function
+
 function nrRecordEvent(event as Object) as Void
     nrLog(["RECORD NEW EVENT = ", event])
+    nrApplyObfuscationToEvent(event)
     m.nrEventArrayIndex = nrAddSample(event, m.nrEventArray, m.nrEventArrayIndex, m.nrEventArrayK)
 end function
 

--- a/components/NewRelicAgent/NRAgent.xml
+++ b/components/NewRelicAgent/NRAgent.xml
@@ -22,6 +22,7 @@
         <function name="nrSceneLoaded"/>
         <function name="nrAddDomainSubstitution"/>
         <function name="nrDelDomainSubstitution"/>
+        <function name="nrSetObfuscationRules"/>
         <function name="nrAppStarted"/>
         <function name="nrSendSystemEvent"/>
         <function name="nrSendVideoEvent"/>

--- a/source/NewRelicAgent.brs
+++ b/source/NewRelicAgent.brs
@@ -109,6 +109,14 @@ function nrDelDomainSubstitution(nr as object, pattern as String) as Void
     nr.callFunc("nrDelDomainSubstitution", pattern)
 end function
 
+' Set obfuscation rules to mask sensitive data in all outgoing events.
+'
+' @param nr New Relic Agent object
+' @param rules Array of { regex: String, replacement: String } objects
+function nrSetObfuscationRules(nr as Object, rules as Object) as Void
+    nr.callFunc("nrSetObfuscationRules", rules)
+end function
+
 ' Send an APP_STARTED event of type ConnectedDeviceSystem.
 '
 ' @param nr New Relic Agent object.

--- a/source/tests/Test__Main.brs
+++ b/source/tests/Test__Main.brs
@@ -37,8 +37,8 @@ Sub MainTestSuite__SetUp()
     ' Create Dummy Video object and start video tracking
     m.videoObject = CreateObject("roSGNode", "com.newrelic.test.DummyVideo")
     videoContent = createObject("RoSGNode", "ContentNode")
-    videoContent.url = "http://fakedomain.com/fakevideo"
-    videoContent.title = "Fake Video"
+    videoContent.url = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
+    videoContent.title = "Big Buck Bunny"
     m.videoObject.content = videoContent
 End Sub
 

--- a/source/tests/Test__Obfuscation.brs
+++ b/source/tests/Test__Obfuscation.brs
@@ -1,0 +1,294 @@
+Function TestSuite__Obfuscation() as Object
+
+    this = BaseTestSuite()
+    this.Name = "ObfuscationTestSuite"
+
+    this.SetUp = ObfuscationTestSuite__SetUp
+    this.TearDown = ObfuscationTestSuite__TearDown
+
+    ' --- Happy path ---
+    this.addTest("NoRulesConfigured",          TestCase__Obfuscation_NoRulesConfigured)
+    this.addTest("BasicMasking",               TestCase__Obfuscation_BasicMasking)
+    this.addTest("MultipleRules",              TestCase__Obfuscation_MultipleRules)
+    this.addTest("RulesAppliedInOrder",        TestCase__Obfuscation_RulesAppliedInOrder)
+    this.addTest("NonStringValuesUnchanged",   TestCase__Obfuscation_NonStringValuesUnchanged)
+    this.addTest("NoMatch",                    TestCase__Obfuscation_NoMatch)
+    this.addTest("EmptyReplacement",           TestCase__Obfuscation_EmptyReplacement)
+    this.addTest("HttpsUrlMasking",            TestCase__Obfuscation_HttpsUrlMasking)
+    this.addTest("PartialMatch",               TestCase__Obfuscation_PartialMatch)
+    this.addTest("ClearRules",                 TestCase__Obfuscation_ClearRules)
+
+    ' --- Validation / rejection at registration time ---
+    this.addTest("InvalidRegexRejected",        TestCase__Obfuscation_InvalidRegexRejected)
+    this.addTest("EmptyRegexRejected",          TestCase__Obfuscation_EmptyRegexRejected)
+    this.addTest("MissingReplacementRejected",  TestCase__Obfuscation_MissingReplacementRejected)
+    this.addTest("RuleNotObjectRejected",       TestCase__Obfuscation_RuleNotObjectRejected)
+    this.addTest("RulesNotArrayRejected",       TestCase__Obfuscation_RulesNotArrayRejected)
+    this.addTest("NonStringRegexRejected",      TestCase__Obfuscation_NonStringRegexRejected)
+
+    return this
+End Function
+
+'================================================================
+' SetUp / TearDown
+'================================================================
+
+Sub ObfuscationTestSuite__SetUp()
+    print "Obfuscation SetUp"
+    if m.nr = invalid
+        m.nr = NewRelic("ACCOUNT_ID", "API_KEY", "APP_NAME", "APP_TOKEN", "US", true)
+    end if
+    ' Stop harvest timer so events stay in the buffer until we extract them
+    nrHarvestTimerEvents = m.nr.findNode("nrHarvestTimerEvents")
+    nrHarvestTimerEvents.control = "stop"
+    ' Clear any rules left by a previous test
+    nrSetObfuscationRules(m.nr, [])
+    ' Drain any events left in the buffer
+    m.nr.callFunc("nrExtractAllSamples", "event")
+End Sub
+
+Sub ObfuscationTestSuite__TearDown()
+    print "Obfuscation TearDown"
+    nrSetObfuscationRules(m.nr, [])
+End Sub
+
+'================================================================
+' Helper — record a crafted event and return the buffered copy
+'================================================================
+
+Function ObfuscationSuite__FireAndExtract(mm as Object, attrs as Object) as Object
+    event = { "eventType": "TestAction", "actionName": "TEST_OBFUSCATION" }
+    if attrs <> invalid then event.Append(attrs)
+    mm.nr.callFunc("nrRecordEvent", event)
+    events = mm.nr.callFunc("nrExtractAllSamples", "event")
+    if events.Count() = 0 then return invalid
+    return events[0]
+End Function
+
+'================================================================
+' Happy path tests
+'================================================================
+
+' 1. No rules — event passes through completely unchanged
+Function TestCase__Obfuscation_NoRulesConfigured() as String
+    print "Checking no rules configured..."
+    ev = ObfuscationSuite__FireAndExtract(m, { "url": "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.url, "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8")
+    ])
+End Function
+
+' 2. Single rule replaces the matched portion of a string value
+Function TestCase__Obfuscation_BasicMasking() as String
+    print "Checking basic masking..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "account-[0-9]+", replacement: "ACCOUNT_ID" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, { "info": "user account-12345 info" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.info, "user ACCOUNT_ID info")
+    ])
+End Function
+
+' 3. Multiple rules — each rule applied to every string attribute in order
+Function TestCase__Obfuscation_MultipleRules() as String
+    print "Checking multiple rules..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "account-[0-9]+", replacement: "ACCOUNT_ID" },
+        { regex: "token=[^&]+",    replacement: "token=REDACTED" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, {
+        "info": "account-99 with token=secret123&other=val"
+    })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.info, "ACCOUNT_ID with token=REDACTED&other=val")
+    ])
+End Function
+
+' 4. Rules run in order — output of rule N is the input to rule N+1
+Function TestCase__Obfuscation_RulesAppliedInOrder() as String
+    print "Checking rules applied in order..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "secret",  replacement: "MASKED" },
+        { regex: "MASKED",  replacement: "DOUBLE_MASKED" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, { "field": "secret" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.field, "DOUBLE_MASKED")
+    ])
+End Function
+
+' 5. Integer and boolean attribute values are never touched
+Function TestCase__Obfuscation_NonStringValuesUnchanged() as String
+    print "Checking non-string values unchanged..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: ".*", replacement: "REDACTED" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, { "numAttr": 42, "boolAttr": true })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.numAttr, 42)
+        m.assertEqual(ev.boolAttr, true)
+    ])
+End Function
+
+' 6. Rule that does not match — string value is left exactly as-is
+Function TestCase__Obfuscation_NoMatch() as String
+    print "Checking no match leaves value unchanged..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "account-[0-9]+", replacement: "ACCOUNT_ID" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, { "info": "no sensitive data here" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.info, "no sensitive data here")
+    ])
+End Function
+
+' 7. Empty replacement string — matched content is deleted from the value
+Function TestCase__Obfuscation_EmptyReplacement() as String
+    print "Checking empty replacement deletes matched content..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "secret", replacement: "" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, { "field": "mysecretvalue" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.field, "myvalue")
+    ])
+End Function
+
+' 8. Full HTTPS URL (including query string) is replaced in one shot
+Function TestCase__Obfuscation_HttpsUrlMasking() as String
+    print "Checking HTTPS URL masking..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "https://.*", replacement: "REDACTED_URL" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, {
+        "contentSrc": "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8?token=abc123&quality=high"
+    })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.contentSrc, "REDACTED_URL")
+    ])
+End Function
+
+' 9. Only the matched portion is replaced; surrounding text is kept intact
+Function TestCase__Obfuscation_PartialMatch() as String
+    print "Checking partial match preserves surrounding text..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "/users/[^/]+", replacement: "/users/USER_ID" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, {
+        "path": "https://api.example.com/users/john.doe/profile"
+    })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.path, "https://api.example.com/users/USER_ID/profile")
+    ])
+End Function
+
+' 10. Clearing rules with [] stops all masking
+Function TestCase__Obfuscation_ClearRules() as String
+    print "Checking clearing rules stops masking..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "account-[0-9]+", replacement: "ACCOUNT_ID" }
+    ])
+    ' Confirm masking is active before clearing
+    ev = ObfuscationSuite__FireAndExtract(m, { "field": "account-99" })
+    if ev.field <> "ACCOUNT_ID" then return "Rules were not applied before clearing"
+
+    ' Clear all rules
+    nrSetObfuscationRules(m.nr, [])
+
+    ' Confirm value is no longer masked
+    ev = ObfuscationSuite__FireAndExtract(m, { "field": "account-99" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.field, "account-99")
+    ])
+End Function
+
+'================================================================
+' Validation / rejection tests
+' All expect: nrSetObfuscationRules rejects the bad input, rules
+' remain as [] (from setUp), and sensitive values pass through.
+'================================================================
+
+' 11. Malformed regex pattern — entire rule set rejected
+Function TestCase__Obfuscation_InvalidRegexRejected() as String
+    print "Checking invalid regex pattern rejected at registration..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "[unclosed", replacement: "X" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, { "field": "account-99" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.field, "account-99")
+    ])
+End Function
+
+' 12. Empty regex string — rule set rejected
+Function TestCase__Obfuscation_EmptyRegexRejected() as String
+    print "Checking empty regex string rejected at registration..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "", replacement: "X" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, { "field": "test" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.field, "test")
+    ])
+End Function
+
+' 13. Rule is missing the replacement key — rule set rejected
+Function TestCase__Obfuscation_MissingReplacementRejected() as String
+    print "Checking rule with missing replacement key rejected..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: "account-[0-9]+" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, { "field": "account-99" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.field, "account-99")
+    ])
+End Function
+
+' 14. A rule is a plain string instead of an object — rule set rejected
+Function TestCase__Obfuscation_RuleNotObjectRejected() as String
+    print "Checking non-object rule rejected..."
+    nrSetObfuscationRules(m.nr, ["not-an-object"])
+    ev = ObfuscationSuite__FireAndExtract(m, { "field": "test" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.field, "test")
+    ])
+End Function
+
+' 15. Rules argument is an associative array, not an array — rejected
+Function TestCase__Obfuscation_RulesNotArrayRejected() as String
+    print "Checking non-array rules argument rejected..."
+    nrSetObfuscationRules(m.nr, { regex: "account-[0-9]+", replacement: "X" })
+    ev = ObfuscationSuite__FireAndExtract(m, { "field": "account-99" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.field, "account-99")
+    ])
+End Function
+
+' 16. regex value is an integer instead of a String — rule set rejected
+Function TestCase__Obfuscation_NonStringRegexRejected() as String
+    print "Checking non-string regex value rejected..."
+    nrSetObfuscationRules(m.nr, [
+        { regex: 123, replacement: "X" }
+    ])
+    ev = ObfuscationSuite__FireAndExtract(m, { "field": "123" })
+    return multiAssert([
+        m.assertNotInvalid(ev)
+        m.assertEqual(ev.field, "123")
+    ])
+End Function


### PR DESCRIPTION
## Description
Adds regex-based obfuscation rules to mask sensitive data in all outgoing events before they are sent to New Relic. This feature allows developers to redact PII (Personally Identifiable Information), tokens, user IDs, and other sensitive data from event attributes like `contentSrc`, `origUrl`, and custom attributes.

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## 📺 Roku Device Testing (Required)

Since Roku tests cannot be automated, manual testing on a physical Roku device is **required** for all PRs.

### Manual Testing Checklist

- [x] I have run tests on a physical Roku device
- [x] All existing tests pass on the device
- [x] New functionality (if any) has been manually verified
- [x] Video playback events are being tracked correctly

### Testing Evidence
<!-- Please provide screenshots, logs, or a detailed description of the manual testing performed -->

## Additional Context
<!-- Add any other context about the pull request here -->

## Related Issues
<!-- Link any related issues here using #issue_number -->

---
**Note:** A GitHub Action will post a reminder comment about manual testing requirements.
