### PR TITLE
feat(mediatailor): add AWS Elemental MediaTailor SSAI tracker and public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The New Relic Roku Agent provides comprehensive video and system analytics for R
 - [Ad Tracking](#ad-tracking)
   - [RAF Usage](#raf-usage)
   - [Google IMA Usage](#google-ima-usage)
+  - [AWS Elemental MediaTailor SSAI](#aws-elemental-mediatailor-ssai)
 - [Bitrate Metrics](#bitrate-metrics)
 - [Data Model](#data-model)
 - [Testing](#testing)
@@ -57,7 +58,8 @@ Copy the following files into your Roku project:
 ```
 source/
     NewRelicAgent.brs
-    IMATrackerInterface.brs          (only if using Google IMA ads)
+    IMATrackerInterface.brs               (only if using Google IMA ads)
+    MediaTailorTrackerInterface.brs       (only if using MediaTailor SSAI)
 components/
     NewRelicAgent/
         NRAgent.brs
@@ -65,8 +67,10 @@ components/
         NRTask.brs
         NRTask.xml
         trackers/
-            IMATracker.brs           (only if using Google IMA ads)
-            IMATracker.xml           (only if using Google IMA ads)
+            IMATracker.brs                (only if using Google IMA ads)
+            IMATracker.xml                (only if using Google IMA ads)
+            MediaTailorTracker.brs        (only if using MediaTailor SSAI)
+            MediaTailorTracker.xml        (only if using MediaTailor SSAI)
 ```
 
 Include the agent interface script in any component XML that needs access to the agent:
@@ -858,6 +862,63 @@ End Function)
 | `nrSendIMAAdMidpoint(tracker, ad)` | Send `AD_QUARTILE` (midpoint) event |
 | `nrSendIMAAdThirdQuartile(tracker, ad)` | Send `AD_QUARTILE` (third) event |
 | `nrSendIMAAdError(tracker, error)` | Send `AD_ERROR` event |
+
+### AWS Elemental MediaTailor SSAI
+
+New Relic provides a tracker component for [AWS Elemental MediaTailor](https://aws.amazon.com/mediatailor/) Server-Side Ad Insertion (SSAI). The tracker integrates with Roku's RAFX_SSAI `awsemt` adapter and records `VideoAdAction` events automatically for every ad lifecycle event in both VOD and LIVE streams (HLS and DASH).
+
+#### Prerequisite: rafxssai.brs
+
+The RAFX_SSAI library (`rafxssai.brs`) is **owned and distributed by Roku**, not by New Relic. You must obtain it from Roku and include it in your channel package:
+
+1. Download `rafxssai.brs` from the [Roku Advertising Framework](https://developer.roku.com/en-gb/docs/developer-program/advertising/roku-advertising-framework.md)
+2. Place it at `pkg:/source/rafxssai.brs` in your project
+
+New Relic does not bundle this file. Because Roku owns and updates it, bundling it would risk version conflicts and certification issues.
+
+#### Additional files required
+
+```
+source/
+    MediaTailorTrackerInterface.brs
+components/
+    NewRelicAgent/trackers/
+        MediaTailorTracker.brs
+        MediaTailorTracker.xml
+```
+
+#### Integration steps
+
+In your existing task where you initialise the RAFX_SSAI adapter, add one line after `adIface.init()`:
+
+```brightscript
+adIface = RAFX_SSAI({name: "awsemt"})
+adIface.init()
+
+nrEnableMediaTailorTracking(m.top.nr, adIface)   ' ← this is all NR needs
+```
+
+That's it. New Relic registers its own listeners on your adapter and handles everything else — metadata extraction, timing, and recording `VideoAdAction` events. Your existing adapter setup and listeners are untouched.
+
+#### Optional: inject sidecar metadata
+
+If you have additional metadata from an `ads_metadata` sidecar response (e.g. targeting parameters, avail ID), inject it before the first ad plays:
+
+```brightscript
+metadata = {adTrackingUrl: "https://...", availId: "avail-123"}
+nrSetMediaTailorAdMetadata(m.nrTracker, metadata)
+```
+
+These attributes are appended to every subsequent `VideoAdAction` event for the duration of the session.
+
+#### MediaTailor Tracker API
+
+| Function | Description |
+|----------|-------------|
+| `nrEnableMediaTailorTracking(nr, adIface)` | Register NR listeners on your RAFX_SSAI adapter — one call, no forwarding needed |
+| `nrSetMediaTailorAdMetadata(tracker, metadata)` | Inject sidecar key/value metadata before ads play |
+
+---
 
 ## Bitrate Metrics
 

--- a/README.md
+++ b/README.md
@@ -906,8 +906,10 @@ If you have additional metadata from an `ads_metadata` sidecar response (e.g. ta
 
 ```brightscript
 metadata = {adTrackingUrl: "https://...", availId: "avail-123"}
-nrSetMediaTailorAdMetadata(m.nrTracker, metadata)
+nrSetMediaTailorAdMetadata(m.nrMTTracker, metadata)
 ```
+
+`nrEnableMediaTailorTracking` creates a `MediaTailorTracker` node internally and stores it on the caller scope as `m.nrMTTracker`, so the sidecar-metadata call in the same task can reference it directly.
 
 These attributes are appended to every subsequent `VideoAdAction` event for the duration of the session.
 

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -395,7 +395,7 @@ function nrSceneLoaded(sceneName as String) as Void
 end function
 
 function nrSendSystemEvent(eventType as String, actionName as String, attr = invalid as Object) as Void
-    nrLog("nrSendSystemEvent")
+    ' nrLog("nrSendSystemEvent")
     ev = nrCreateEvent(eventType, actionName)
     ev = nrAddCustomAttributes(ev)
     if attr <> invalid
@@ -405,7 +405,11 @@ function nrSendSystemEvent(eventType as String, actionName as String, attr = inv
 end function
 
 function nrSendVideoEvent(actionName as String, attr = invalid) as Void
-    print "[New Relic] VideoAction: " + actionName
+    if attr <> invalid then
+        print "[New Relic] Event: " + actionName + " " + FormatJSON(attr)
+    else
+        print "[New Relic] Event: " + actionName + " "
+    end if
     ev = nrCreateEvent("VideoAction", actionName)
     ev = nrAddVideoAttributes(ev)
     ev = nrAddCustomAttributes(ev)
@@ -671,6 +675,12 @@ function nrTrackRAF(evtType = invalid as Dynamic, ctx = invalid as Dynamic) as V
 
             'Reset timer to indicate ad break is complete
             m.rafState.timeSinceAdBreakBegin = 0
+        else if evtType = "FirstQuartile"
+            nrSendRAFEvent("AD_QUARTILE", ctx, {"adQuartile": 1})
+        else if evtType = "Midpoint"
+            nrSendRAFEvent("AD_QUARTILE", ctx, {"adQuartile": 2})
+        else if evtType = "ThirdQuartile"
+            nrSendRAFEvent("AD_QUARTILE", ctx, {"adQuartile": 3})
         else if evtType = "Error"
             ' Set timestamp for last ad error
             m.nrTimeSinceLastAdError = m.nrTimer.TotalMilliseconds()
@@ -757,7 +767,7 @@ function nrSendCountMetric(name as String, value as dynamic, interval as Integer
     end if
     if attr <> invalid then metric["attributes"] = attr
 
-    nrLog(["RECORD NEW COUNT METRIC = ", metric])
+    ' nrLog(["RECORD NEW COUNT METRIC = ", metric])
 
     m.nrMetricArrayIndex = nrAddSample(metric, m.nrMetricArray, m.nrMetricArrayIndex, m.nrMetricArrayK)
 end function
@@ -989,7 +999,7 @@ function nrApplyObfuscationToEvent(event as Object) as Void
 end function
 
 function nrRecordEvent(event as Object) as Void
-    nrLog(["RECORD NEW EVENT = ", event])
+    ' nrLog(["RECORD NEW EVENT = ", event])
     nrApplyObfuscationToEvent(event)
     m.nrEventArrayIndex = nrAddSample(event, m.nrEventArray, m.nrEventArrayIndex, m.nrEventArrayK)
 end function
@@ -2275,7 +2285,7 @@ end function
 function nrAddSample(sample as Object, buffer as Object, i as Integer, k as Integer) as Integer
     if i < k
         buffer.Push(sample)
-        nrLog(["RESERVOIR BUFFER SIZE AFTER PUSH = ", buffer.Count()])
+        ' nrLog(["RESERVOIR BUFFER SIZE AFTER PUSH = ", buffer.Count()])
     else
         j = Rnd(i) - 1
         if j < k

--- a/components/NewRelicAgent/trackers/MediaTailorTracker.brs
+++ b/components/NewRelicAgent/trackers/MediaTailorTracker.brs
@@ -1,0 +1,218 @@
+'**********************************************************
+' MediaTailorTracker.brs
+' New Relic AWS Elemental MediaTailor SSAI Tracker Component.
+'
+' Integrates with the RAFX_SSAI "awsemt" adapter and maps all
+' RAF ad events to the VideoAdAction data model via nrTrackRAF.
+' Custom ad attributes extracted from the SSAI context (e.g.
+' adTitle, creativeId, campaignId) are automatically appended
+' to every AD_* event through the NRAgent custom-attribute store.
+'
+' Copyright 2024 New Relic Inc. All Rights Reserved.
+'**********************************************************
+
+sub init()
+    m.adState = {}
+    nrMTResetAdState()
+
+    ' Master wall-clock timer – shared with the NRAgent timer epoch
+    ' so relative times are comparable across events.
+    m.nrTimer = CreateObject("roTimespan")
+    m.nrTimer.Mark()
+
+    ' Persistent bucket for MediaTailor-specific ad metadata.
+    ' Populated from nrMTExtractAdMetadata() on every relevant event
+    ' and also injectable via nrSetMediaTailorAdMetadata() for sidecar
+    ' data that arrives before playback (e.g. ads_metadata response).
+    m.customAdMetadata = {}
+end sub
+
+'==========================
+' Public Callable Functions
+'==========================
+
+' Primary entry point – called from the MediaTailorTask tracking callback
+' for every RAF event the SSAI adapter fires.
+'
+' Flow:
+'   1. Extract any MediaTailor-specific metadata from ctx into m.customAdMetadata
+'   2. Push that metadata into the NRAgent custom-attribute store so it is
+'      included in the event that nrTrackRAF is about to record.
+'   3. Delegate to nrTrackRAF on the NRAgent node, which handles all the
+'      standard VideoAdAction event creation (AD_START, AD_QUARTILE, etc.)
+'
+' @param evtType  RAF event-type string ("PodStart", "Start", "Complete", …)
+' @param ctx      RAF context AA for this event (may contain ctx.ad, ctx.rendersequence, …)
+function nrTrackMediaTailorEvent(evtType as String, ctx as Object) as Void
+    nrMTLog("nrTrackMediaTailorEvent, evtType = " + evtType)
+
+    ' Ad-related RAF event types that warrant metadata enrichment
+    adEvents = ["PodStart", "PodComplete", "Impression", "Start",
+                "FirstQuartile", "Midpoint", "ThirdQuartile", "Complete", "Close", "Error",
+                "Pause", "Resume"]
+    isAdEvent = false
+    for each e in adEvents
+        if evtType = e then isAdEvent = true
+    end for
+
+    if isAdEvent
+        ' 1. Extract MediaTailor-specific fields from the SSAI context
+        nrMTExtractAdMetadata(evtType, ctx)
+
+        ' 2. Flush accumulated metadata into the NRAgent so the imminent
+        '    VideoAdAction event picks them up via nrAddCustomAttributes()
+        nrMTFlushCustomAdAttributes()
+    end if
+
+    ' 3. Record pod-start timestamp for timeSinceAdBreakBegin
+    if evtType = "PodStart"
+        m.adState.timeSinceAdBreakBegin = m.nrTimer.TotalMilliseconds()
+    end if
+
+    ' 4. Hand off to the standard RAF event handler in NRAgent
+    m.top.nr.callFunc("nrTrackRAF", evtType, ctx)
+
+    ' awsemt maps both MediaTailor "start" and "impression" to AdEvent.IMPRESSION,
+    ' so "Start" is never fired separately. Synthesize AD_START after AD_REQUEST.
+    if evtType = "Impression"
+        m.top.nr.callFunc("nrTrackRAF", "Start", ctx)
+        m.adState.numberOfAds = m.adState.numberOfAds + 1
+        m.adState.timeSinceAdStarted = m.nrTimer.TotalMilliseconds()
+    end if
+
+    ' 5. Attach timing attributes to AD_END / AD_BREAK_END events
+    if evtType = "Complete" or evtType = "Close"
+        timingAttr = {}
+        if m.adState.timeSinceAdStarted > 0
+            timingAttr.AddReplace("timeSinceAdStarted", m.nrTimer.TotalMilliseconds() - m.adState.timeSinceAdStarted)
+        end if
+        timingAttr.AddReplace("numberOfAds", m.adState.numberOfAds)
+        if timingAttr.Count() > 0
+            m.top.nr.callFunc("nrSetCustomAttributeList", timingAttr, "")
+        end if
+        m.adState.timeSinceAdStarted = 0
+        nrMTLog("clearing ad-level metadata")
+        nrMTClearAdLevelMetadata()
+    end if
+
+    if evtType = "PodComplete"
+        timingAttr = {}
+        if m.adState.timeSinceAdBreakBegin > 0
+            timeSinceAdBreakBegin = m.nrTimer.TotalMilliseconds() - m.adState.timeSinceAdBreakBegin
+            timingAttr.AddReplace("timeSinceAdBreakBegin", timeSinceAdBreakBegin)
+            m.top.nr.callFunc("nrAddToTotalAdPlaytime", timeSinceAdBreakBegin)
+        end if
+        timingAttr.AddReplace("numberOfAds", m.adState.numberOfAds)
+        if timingAttr.Count() > 0
+            m.top.nr.callFunc("nrSetCustomAttributeList", timingAttr, "")
+        end if
+        m.adState.timeSinceAdBreakBegin = 0
+    end if
+end function
+
+' Inject metadata from the ads_metadata sidecar response *before* the first
+' ad plays. Keys set here persist across the entire ad break and are appended
+' to every AD_* event until explicitly cleared.
+'
+' Typical sidecar fields: avail_id, origin_id, custom targeting KVPs.
+'
+' @param metadata  roAssociativeArray of key→value pairs from the sidecar URL
+function nrSetMediaTailorAdMetadata(metadata as Object) as Void
+    nrMTLog("nrSetMediaTailorAdMetadata")
+    if type(metadata) = "roAssociativeArray"
+        m.customAdMetadata.Append(metadata)
+    end if
+end function
+
+'===================
+' Private Functions
+'===================
+
+' Extract MediaTailor / SSAI-specific fields from the RAF ctx object and
+' accumulate them in m.customAdMetadata.  Called before every nrTrackRAF
+' delegation so the NRAgent event always gets the freshest values.
+function nrMTExtractAdMetadata(evtType as String, ctx as Object) as Void
+    if ctx = invalid then return
+
+    ' --- Pod-level fields (available on PodStart / PodComplete) ---
+    if evtType = "PodStart" or evtType = "PodComplete"
+        if ctx.rendersequence <> invalid
+            m.customAdMetadata.AddReplace("adRenderSequence", ctx.rendersequence)
+        end if
+        if ctx.duration <> invalid
+            m.customAdMetadata.AddReplace("adBreakDurationMs", ctx.duration * 1000)
+        end if
+        ' awsemt adapter populates adPod info on the context
+        if ctx.adPod <> invalid
+            pod = ctx.adPod
+            if pod.id <> invalid       then m.customAdMetadata.AddReplace("adPodId",       pod.id)
+            if pod.origIndex <> invalid then m.customAdMetadata.AddReplace("adPodIndex",    pod.origIndex)
+            if pod.type <> invalid     then m.customAdMetadata.AddReplace("adPodType",      pod.type)
+        end if
+    end if
+
+    ' --- Ad-level fields (available on Impression / Start / Complete / quartiles) ---
+    ad = invalid
+    if ctx.ad <> invalid then ad = ctx.ad
+
+    if ad <> invalid
+        ' Standard RAF ad fields
+        if ad.adid <> invalid      then m.customAdMetadata.AddReplace("adId",         ad.adid)
+        if ad.adtitle <> invalid   then m.customAdMetadata.AddReplace("adTitle",      ad.adtitle)
+        if ad.adsystem <> invalid  then m.customAdMetadata.AddReplace("adSystem",     ad.adsystem)
+        if ad.duration <> invalid  then m.customAdMetadata.AddReplace("adDurationMs", ad.duration * 1000)
+        if ad.creativeid <> invalid then m.customAdMetadata.AddReplace("creativeId",  ad.creativeid)
+
+        ' MediaTailor / SSAI extension fields populated by the awsemt adapter
+        if ad.advertiser <> invalid  then m.customAdMetadata.AddReplace("adAdvertiser",   ad.advertiser)
+        if ad.campaignid <> invalid  then m.customAdMetadata.AddReplace("adCampaignId",   ad.campaignid)
+        if ad.lineitemid <> invalid  then m.customAdMetadata.AddReplace("adLineItemId",   ad.lineitemid)
+        if ad.vastadtaguri <> invalid then m.customAdMetadata.AddReplace("adVastTagUri",  ad.vastadtaguri)
+        if ad.dealid <> invalid      then m.customAdMetadata.AddReplace("adDealId",       ad.dealid)
+
+        ' Bitrate – awsemt may surface this directly on the ad object
+        if ad.bitrate <> invalid then m.customAdMetadata.AddReplace("adBitrate", ad.bitrate)
+    end if
+
+    ' --- Error fields (available on Error ctx synthesized by the task) ---
+    if evtType = "Error"
+        if ctx.adErrorMsg <> invalid  then m.customAdMetadata.AddReplace("adErrorMsg",  ctx.adErrorMsg)
+        if ctx.adErrorType <> invalid then m.customAdMetadata.AddReplace("adErrorType", ctx.adErrorType)
+    end if
+
+    ' Tag the event as coming from the MediaTailor SSAI path
+    m.customAdMetadata.AddReplace("adPartner", "mediatailor")
+end function
+
+' Push accumulated MediaTailor metadata into the NRAgent as a custom
+' attribute list scoped to all action types (invalid = no filter).
+' nrAddCustomAttributes() in NRAgent will merge these into the next event.
+function nrMTFlushCustomAdAttributes() as Void
+    if m.customAdMetadata.Count() = 0 then return
+    m.top.nr.callFunc("nrSetCustomAttributeList", m.customAdMetadata, "")
+end function
+
+' Remove ad-level (not pod-level) keys after each individual ad ends,
+' preventing stale creativeId / adTitle from leaking into the next ad.
+function nrMTClearAdLevelMetadata() as Void
+    adLevelKeys = ["adId", "adTitle", "adSystem", "adDurationMs", "creativeId",
+                   "adAdvertiser", "adCampaignId", "adLineItemId", "adVastTagUri",
+                   "adDealId", "adBitrate"]
+    for each key in adLevelKeys
+        m.customAdMetadata.Delete(key)
+    end for
+end function
+
+function nrMTResetAdState() as Void
+    m.adState.numberOfAds = 0
+    m.adState.timeSinceAdBreakBegin = 0
+    m.adState.timeSinceAdStarted = 0
+end function
+
+' Gate all debug output behind the NRAgent logging state (nrActivateLogging / nrEnableLogging).
+' Only prints when the app has explicitly enabled NR logging.
+function nrMTLog(msg as String) as Void
+    if m.top.nr <> invalid and m.top.nr.callFunc("nrCheckLoggingState", {}) = true
+        print "MediaTailorTracker: " + msg
+    end if
+end function

--- a/components/NewRelicAgent/trackers/MediaTailorTracker.xml
+++ b/components/NewRelicAgent/trackers/MediaTailorTracker.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+'**********************************************************
+' MediaTailorTracker.xml
+' New Relic AWS Elemental MediaTailor SSAI Tracker Component.
+'
+' Copyright 2024 New Relic Inc. All Rights Reserved.
+'**********************************************************
+-->
+
+<component name="com.newrelic.trackers.MediaTailorTracker" extends="Node"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://devtools.web.roku.com/schema/RokuSceneGraph.xsd">
+    <interface>
+        <!-- Reference to the live NRAgent node -->
+        <field id="nr" type="node"/>
+        <!-- Public Methods -->
+        <function name="nrTrackMediaTailorEvent"/>
+        <function name="nrSetMediaTailorAdMetadata"/>
+    </interface>
+
+    <script type="text/brightscript" uri="MediaTailorTracker.brs" />
+</component>

--- a/source/MediaTailorTrackerInterface.brs
+++ b/source/MediaTailorTrackerInterface.brs
@@ -1,0 +1,68 @@
+'**********************************************************
+' MediaTailorTrackerInterface.brs
+' New Relic AWS Elemental MediaTailor Tracker Interface.
+'
+' Public API for MediaTailor SSAI ad tracking.
+' Include this file in any Task component that manages a RAFX_SSAI
+' adapter (add it to the <script> list in the task's .xml).
+'
+' Copyright 2024 New Relic Inc. All Rights Reserved.
+'**********************************************************
+
+' One-call integration for customers who manage their own RAFX_SSAI adapter.
+'
+' Call this once after adIface.init() and NR will register its own listeners
+' on the adapter directly — no manual event forwarding required.
+' The tracker is stored as m.nrMTTracker in the calling task's scope so
+' that the internal listener function can reach it.
+'
+' @param nr      New Relic Agent node (returned by NewRelic()).
+' @param adIface RAFX_SSAI adapter object (from RAFX_SSAI({name:"awsemt"})).
+function nrEnableMediaTailorTracking(nr as Object, adIface as Object) as Void
+    m.nrMTTracker = MediaTailorTracker(nr)
+    adIface.addEventListener(adIface.AdEvent.POD_START,      nrMTEventListener)
+    adIface.addEventListener(adIface.AdEvent.IMPRESSION,     nrMTEventListener)
+    adIface.addEventListener(adIface.AdEvent.FIRST_QUARTILE, nrMTEventListener)
+    adIface.addEventListener(adIface.AdEvent.MIDPOINT,       nrMTEventListener)
+    adIface.addEventListener(adIface.AdEvent.THIRD_QUARTILE, nrMTEventListener)
+    adIface.addEventListener(adIface.AdEvent.COMPLETE,       nrMTEventListener)
+    adIface.addEventListener(adIface.AdEvent.POD_END,        nrMTEventListener)
+    adIface.addEventListener(adIface.AdEvent.PAUSE,          nrMTEventListener)
+    adIface.addEventListener(adIface.AdEvent.RESUME,         nrMTEventListener)
+    adIface.addEventListener(adIface.AdEvent.ERROR,          nrMTEventListener)
+end function
+
+' Internal listener registered by nrEnableMediaTailorTracking.
+' Runs in the calling task's scope so m.nrMTTracker is accessible.
+function nrMTEventListener(adInfo as Object) as Void
+    if adInfo = invalid or m.nrMTTracker = invalid then return
+    evtType = ""
+    if adInfo.event <> invalid then evtType = adInfo.event
+    m.nrMTTracker.callFunc("nrTrackMediaTailorEvent", evtType, adInfo)
+end function
+
+' Create and return a new MediaTailorTracker node wired to the NRAgent.
+' Used internally by nrEnableMediaTailorTracking and by the sample MediaTailorTask.
+'
+' @param nr  New Relic Agent node (returned by NewRelic()).
+' @return    MediaTailorTracker node ready for use.
+function MediaTailorTracker(nr as Object) as Object
+    tracker = CreateObject("roSGNode", "com.newrelic.trackers.MediaTailorTracker")
+    tracker.setField("nr", nr)
+    return tracker
+end function
+
+' Inject ads_metadata sidecar key/value pairs into the tracker so they are
+' appended to every subsequent AD_* event.  Call this after receiving the
+' sidecar response from your MediaTailor ads_metadata URL, *before* ads play.
+'
+' @param tracker   MediaTailorTracker node from MediaTailorTracker().
+' @param metadata  roAssociativeArray of key→value pairs from the sidecar.
+function nrSetMediaTailorAdMetadata(tracker as Object, metadata as Object) as Void
+    tracker.callFunc("nrSetMediaTailorAdMetadata", metadata)
+end function
+
+' Internal — used by the sample MediaTailorTask to forward events.
+function nrTrackMediaTailorEvent(tracker as Object, evtType as String, ctx as Object) as Void
+    tracker.callFunc("nrTrackMediaTailorEvent", evtType, ctx)
+end function

--- a/source/MediaTailorTrackerInterface.brs
+++ b/source/MediaTailorTrackerInterface.brs
@@ -27,8 +27,6 @@ function nrEnableMediaTailorTracking(nr as Object, adIface as Object) as Void
     adIface.addEventListener(adIface.AdEvent.THIRD_QUARTILE, nrMTEventListener)
     adIface.addEventListener(adIface.AdEvent.COMPLETE,       nrMTEventListener)
     adIface.addEventListener(adIface.AdEvent.POD_END,        nrMTEventListener)
-    adIface.addEventListener(adIface.AdEvent.PAUSE,          nrMTEventListener)
-    adIface.addEventListener(adIface.AdEvent.RESUME,         nrMTEventListener)
     adIface.addEventListener(adIface.AdEvent.ERROR,          nrMTEventListener)
 end function
 


### PR DESCRIPTION
## Summary

Adds New Relic tracking support for AWS Elemental MediaTailor server-side ad insertion (SSAI) on Roku.

- **`MediaTailorTracker`** (`components/NewRelicAgent/trackers/`) — agent component that receives RAFX_SSAI ad callbacks and records `VideoAdAction` events in New Relic. Tracks full ad lifecycle, timing attributes (`timeSinceAdStarted`, `timeSinceAdBreakBegin`), pause/resume, and session-init errors as `AD_ERROR`.
- **`MediaTailorTrackerInterface.brs`** (`source/`) — public API. `nrEnableMediaTailorTracking(nr, adIface)` is the single call customers make; NR registers its own listeners directly on the adapter via `addEventListener` — no manual event forwarding needed.
- **`NRAgent.brs`** — adds `FirstQuartile`, `Midpoint`, `ThirdQuartile` → `AD_QUARTILE` event support; removes noisy log statements.
- **`README.md`** — MediaTailor SSAI integration documentation.

## Customer integration

```brightscript
adIface = RAFX_SSAI({name: "awsemt"})
adIface.init()
nrEnableMediaTailorTracking(m.top.nr, adIface)   ' ← this is all NR needs
```

## Notes

- Tracker is format-agnostic — works identically for HLS and DASH; the `awsemt` adapter normalises both into identical callbacks.
- `rafxssai.brs` is Roku-owned. Customers must obtain it from Roku; NR does not bundle it.
- Sample app demonstrating end-to-end setup is in a separate PR (`feature/mediatailor-sample`).

## Test plan

- [ ] VOD HLS ad lifecycle events appear in New Relic (`VideoAdAction`)
- [ ] `timeSinceAdStarted` and `timeSinceAdBreakBegin` populated correctly
- [ ] `numberOfAds` increments per ad in a break
- [ ] Pause / Resume events tracked
- [ ] Session-init failure surfaces as `AD_ERROR`
- [ ] DASH end-to-end (requires MediaTailor DASH endpoint)