### PR TITLE
feat: add JP region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Build a New Relic Agent object. Call this once at app startup.
 | `apikey` | String | Yes | — | Insights API key |
 | `appName` | String | Yes | — | Application name |
 | `appToken` | String | Yes | — | Mobile Application Token |
-| `region` | String | No | `"US"` | API region: `"US"`, `"EU"`, or `"staging"` |
+| `region` | String | No | `"US"` | API region: `"US"`, `"EU"`, `"staging"`, or `"JP"` |
 | `activeLogs` | Boolean | No | `false` | Enable agent debug logging |
 
 ```brightscript

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Build a New Relic Agent object. Call this once at app startup.
 | `apikey` | String | Yes | — | Insights API key |
 | `appName` | String | Yes | — | Application name |
 | `appToken` | String | Yes | — | Mobile Application Token |
-| `region` | String | No | `"US"` | API region: `"US"`, `"EU"`, or `"staging"` |
+| `region` | String | No | `"US"` | API region: `"US"`, `"EU"`, `"staging"`, or `"JP"` |
 | `activeLogs` | Boolean | No | `false` | Enable agent debug logging |
 
 ```brightscript

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ The New Relic Roku Agent provides comprehensive video and system analytics for R
 
 - [Installation](#installation)
 - [Prerequisites](#prerequisites)
+- [Platform Notes](#platform-notes)
+  - [OS_NAME Requirement](#os_name-requirement)
+  - [Two Data Paths](#two-data-paths--two-new-relic-accounts)
 - [Usage](#usage)
 - [Best Practices](#best-practices)
 - [API Reference](#api-reference)
@@ -84,8 +87,39 @@ Include the agent interface script in any component XML that needs access to the
 Before using the agent, ensure you have:
 
 - **New Relic Account** — Active New Relic account with valid credentials (`ACCOUNT_ID`, `API_KEY`, `APP_TOKEN`)
-- **Roku Device** — Firmware 8.1 or higher
+- **Roku Device** — Roku OS 11.x or higher (the OS floor is enforced via the Roku Partner Dashboard, not via manifest keys)
 - **Roku Development Environment** — Ability to side-load channels for development
+
+## Platform Notes
+
+### OS_NAME Requirement
+
+The New Relic mobile collector requires `OS_NAME` to be set to `"Android"` in the agent's internal app info. This is handled automatically by the SDK — **you do not need to set it manually**. Events delivered to New Relic correctly report `osName: "RokuOS"` in the event payload. This is a transport-layer requirement only.
+
+> **Warning:** If you are constructing `nrCreateAppInfo` manually or copying integration patterns from non-Roku SDKs, ensure `OS_NAME` is `"Android"`. Sending `OS_NAME = "Roku"` results in an HTTP 400 from the mobile collector and **silent data loss** — no error is surfaced to the app.
+
+### Two Data Paths — Two New Relic Accounts
+
+The Roku Agent routes telemetry across two separate collectors, each requiring a different credential and landing in a different account:
+
+| Data Path | Events | Collector | Credential | Account |
+|-----------|--------|-----------|------------|---------|
+| **Video path** | `VideoAction`, `VideoAdAction`, `VideoErrorAction`, `VideoCustomAction`, `QOE_AGGREGATE` | `mobile-collector.newrelic.com` | `APP_TOKEN` (`-NRMA` suffix) | **Production account** |
+| **System path** | `ConnectedDeviceSystem` (`APP_STARTED`, `SCENE_LOADED`, `HTTP_REQUEST`, `HTTP_RESPONSE`, bandwidth) | `insights-collector.newrelic.com` | `API_KEY` | **Staging/ingest account** |
+
+**If you see no data after integrating**, verify you are querying the correct account for each event type:
+
+```sql
+-- Query video events (production account, via APP_TOKEN)
+SELECT * FROM VideoAction SINCE 30 minutes ago
+
+-- Query system events (account matching your API_KEY)
+SELECT * FROM ConnectedDeviceSystem SINCE 30 minutes ago
+```
+
+This split is intentional: video telemetry uses the Mobile SDK collector to support session stitching and QoE aggregation, while system events use the standard ingest pipeline.
+
+---
 
 ## Usage
 
@@ -167,6 +201,18 @@ end sub
 
 function nrRefUpdated()
     m.nr = m.top.nr
+
+    ' REQUIRED: agent node must be in the scene render tree or harvest timers
+    ' started in NRAgent.init() will be inert and no events will be delivered.
+    if m.top.nr.getParent() = invalid then m.top.appendChild(m.top.nr)
+
+    ' Restart timers after rooting — timers started while unparented are silently
+    ' dropped by the SceneGraph runtime and require a stop→start cycle to fire.
+    nrRestartHarvestTimers(m.nr)
+
+    ' Flush any boot events (e.g. APP_STARTED) immediately. Without this, events
+    ' buffered before the first harvest cycle are lost on crashes or short sessions.
+    nrForceHarvestEvents(m.nr)
 
     ' Start video tracking
     NewRelicVideoStart(m.nr, m.video)

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -185,7 +185,7 @@ function nrMobileCollectorApiUrl() as String
     if m.nrRegion = "US" OR m.nrRegion = "us"
         return "https://mobile-collector.newrelic.com/mobile/v4/connect"
     else if m.nrRegion = "EU" OR m.nrRegion = "eu"
-        return "https://mobile-collector.eu.newrelic.com/mobile/v4/connect"
+        return "https://mobile-collector.eu01.nr-data.net/mobile/v4/connect"
     else if(m.nrRegion = "JP" OR m.nrRegion = "jp")
          return  "https://mobile-collector.jp.nr-data.net/mobile/v4/connect"
     else if m.nrRegion = "staging"

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -1349,9 +1349,9 @@ end function
 '       We could even pass an object containing different endpoints for events, metrics and logs.
 
 function nrEventApiUrl() as String
-    if m.nrRegion = "US"
+    if m.nrRegion = "US" OR m.nrRegion = "us"
         return "https://insights-collector.newrelic.com/v1/accounts/" + m.nrAccountNumber + "/events"
-    else if m.nrRegion = "EU"
+    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
         return "https://insights-collector.eu01.nr-data.net/v1/accounts/" + m.nrAccountNumber + "/events"
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
@@ -1360,9 +1360,9 @@ function nrEventApiUrl() as String
 end function
 
 function nrLogApiUrl() as String
-    if m.nrRegion = "US"
+    if m.nrRegion = "US" OR m.nrRegion = "us"
         return "https://log-api.newrelic.com/log/v1"
-    else if m.nrRegion = "EU"
+    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
         return "https://log-api.eu.newrelic.com/log/v1"
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
@@ -1371,9 +1371,9 @@ function nrLogApiUrl() as String
 end function
 
 function nrMetricApiUrl() as String
-    if m.nrRegion = "US"
+    if m.nrRegion = "US" OR m.nrRegion = "us"
         return "https://metric-api.newrelic.com/metric/v1"
-    else if m.nrRegion = "EU"
+    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
         return "https://metric-api.eu.newrelic.com/metric/v1"
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -183,14 +183,14 @@ end function
 
 function nrMobileCollectorApiUrl() as String
     if m.nrRegion = "US" OR m.nrRegion = "us"
-        return "https://mobile-collector.newrelic.com/mobile/v3/data"
+        return "https://mobile-collector.newrelic.com/mobile/v4/connect"
     else if m.nrRegion = "EU" OR m.nrRegion = "eu"
-        return "https://mobile-collector.eu.newrelic.com/mobile/v3/data"
+        return "https://mobile-collector.eu.newrelic.com/mobile/v4/connect"
     else if(m.nrRegion = "JP" OR m.nrRegion = "jp")
-            urlReq.SetUrl("https://mobile-collector.jp.nr-data.net/mobile/v4/connect")
+         return  "https://mobile-collector.jp.nr-data.net/mobile/v4/connect"
     else if m.nrRegion = "staging"
      'NOTE: set address hosting the test server
-     return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
+     return "https://staging-mobile-collector.newrelic.com/mobile/v4/connect"
      end if
 end function
 

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -186,18 +186,23 @@ function nrMobileCollectorApiUrl() as String
         return "https://mobile-collector.newrelic.com/mobile/v3/data"
     else if m.nrRegion = "EU" OR m.nrRegion = "eu"
         return "https://mobile-collector.eu.newrelic.com/mobile/v3/data"
+    else if(m.nrRegion = "JP")
+            urlReq.SetUrl("https://mobile-collector.jp.nr-data.net/mobile/v4/connect")
     else if m.nrRegion = "staging"
-            'NOTE: set address hosting the test server
-            return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
-        end if
+     'NOTE: set address hosting the test server
+     return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
+     end if
 end function
 
 function nrConnect(appToken as string, body as object)
     jsonRequestBody = FormatJSON(body)
     urlReq = CreateObject("roUrlTransfer")    
     rport = CreateObject("roMessagePort")
-    url = box(nrMobileCollectorApiUrl())
-    urlReq.SetUrl(url)
+    if(m.nrRegion = "staging")
+        urlReq.SetUrl("https://staging-mobile-collector.newrelic.com/mobile/v4/connect")
+    else
+        urlReq.SetUrl("https://mobile-collector.newrelic.com/mobile/v4/connect")
+    end if
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)
@@ -1363,6 +1368,8 @@ function nrEventApiUrl() as String
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
         return "https://staging-insights-collector.newrelic.com/v1/accounts/" + m.nrAccountNumber + "/events"
+    else if m.nrRegion = "JP"
+        return "https://insights-collector.jp.nr-data.net/v1/accounts/" + m.nrAccountNumber + "/events"
     end if
 end function
 
@@ -1373,7 +1380,9 @@ function nrLogApiUrl() as String
         return "https://log-api.eu.newrelic.com/log/v1"
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
-        return "https://staging-log-api.newrelic.com/log/v1" 
+        return "https://staging-log-api.newrelic.com/log/v1"
+    else if m.nrRegion = "JP"
+        return "https://log-api.jp.newrelic.com/log/v1"
     end if
 end function
 
@@ -1385,6 +1394,8 @@ function nrMetricApiUrl() as String
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
         return "https://staging-metric-api.newrelic.com/metric/v1"
+    else if m.nrRegion = "JP"
+        return "https://metric-api.jp.newrelic.com/metric/v1"
     end if
 end function
 

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -181,16 +181,23 @@ function NewRelicInit(account as String, apikey as String,appName as String, reg
     nrLog(["NewRelicInit complete. appName=", m.appName, ", region=", m.nrRegion, ", logging=", m.nrLogsState])
 end function
 
+function nrMobileCollectorApiUrl() as String
+    if m.nrRegion = "US" OR m.nrRegion = "us"
+        return "https://mobile-collector.newrelic.com/mobile/v3/data"
+    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
+        return "https://mobile-collector.eu.newrelic.com/mobile/v3/data"
+    else if m.nrRegion = "staging"
+            'NOTE: set address hosting the test server
+            return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
+        end if
+end function
 
 function nrConnect(appToken as string, body as object)
     jsonRequestBody = FormatJSON(body)
     urlReq = CreateObject("roUrlTransfer")    
     rport = CreateObject("roMessagePort")
-    if(m.nrRegion = "staging")
-        urlReq.SetUrl("https://staging-mobile-collector.newrelic.com/mobile/v4/connect")
-    else
-        urlReq.SetUrl("https://mobile-collector.newrelic.com/mobile/v4/connect")
-    end if
+    url = box(nrMobileCollectorApiUrl())
+    urlReq.SetUrl(url)
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -186,7 +186,7 @@ function nrMobileCollectorApiUrl() as String
         return "https://mobile-collector.newrelic.com/mobile/v3/data"
     else if m.nrRegion = "EU" OR m.nrRegion = "eu"
         return "https://mobile-collector.eu.newrelic.com/mobile/v3/data"
-    else if(m.nrRegion = "JP")
+    else if(m.nrRegion = "JP" OR m.nrRegion = "jp")
             urlReq.SetUrl("https://mobile-collector.jp.nr-data.net/mobile/v4/connect")
     else if m.nrRegion = "staging"
      'NOTE: set address hosting the test server

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -198,11 +198,7 @@ function nrConnect(appToken as string, body as object)
     jsonRequestBody = FormatJSON(body)
     urlReq = CreateObject("roUrlTransfer")    
     rport = CreateObject("roMessagePort")
-    if(m.nrRegion = "staging")
-        urlReq.SetUrl("https://staging-mobile-collector.newrelic.com/mobile/v4/connect")
-    else
-        urlReq.SetUrl("https://mobile-collector.newrelic.com/mobile/v4/connect")
-    end if
+    urlReq.SetUrl(nrMobileCollectorApiUrl())
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)
@@ -1389,7 +1385,7 @@ function nrEventApiUrl() as String
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
         return "https://staging-insights-collector.newrelic.com/v1/accounts/" + m.nrAccountNumber + "/events"
-    else if m.nrRegion = "JP"
+    else if m.nrRegion = "JP" OR m.nrRegion = "jp"
         return "https://insights-collector.jp.nr-data.net/v1/accounts/" + m.nrAccountNumber + "/events"
     end if
 end function
@@ -1415,7 +1411,7 @@ function nrMetricApiUrl() as String
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
         return "https://staging-metric-api.newrelic.com/metric/v1"
-    else if m.nrRegion = "JP"
+    else if m.nrRegion = "JP" OR m.nrRegion = "jp"
         return "https://metric-api.jp.newrelic.com/metric/v1"
     end if
 end function

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -186,6 +186,8 @@ function nrMobileCollectorApiUrl() as String
         return "https://mobile-collector.newrelic.com/mobile/v4/connect"
     else if m.nrRegion = "EU" OR m.nrRegion = "eu"
         return "https://mobile-collector.eu01.nr-data.net/mobile/v4/connect"
+    else if m.nrRegion = "JP" OR m.nrRegion = "jp"
+        return "https://mobile-collector.jp.nr-data.net/mobile/v4/connect"
     else if m.nrRegion = "staging"
             'NOTE: set address hosting the test server
             return "https://staging-mobile-collector.newrelic.com/mobile/v4/connect"
@@ -196,8 +198,11 @@ function nrConnect(appToken as string, body as object)
     jsonRequestBody = FormatJSON(body)
     urlReq = CreateObject("roUrlTransfer")    
     rport = CreateObject("roMessagePort")
-    url = box(nrMobileCollectorApiUrl())
-    urlReq.SetUrl(url)
+    if(m.nrRegion = "staging")
+        urlReq.SetUrl("https://staging-mobile-collector.newrelic.com/mobile/v4/connect")
+    else
+        urlReq.SetUrl("https://mobile-collector.newrelic.com/mobile/v4/connect")
+    end if
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)
@@ -1384,6 +1389,8 @@ function nrEventApiUrl() as String
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
         return "https://staging-insights-collector.newrelic.com/v1/accounts/" + m.nrAccountNumber + "/events"
+    else if m.nrRegion = "JP"
+        return "https://insights-collector.jp.nr-data.net/v1/accounts/" + m.nrAccountNumber + "/events"
     end if
 end function
 
@@ -1395,6 +1402,8 @@ function nrLogApiUrl() as String
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
         return "https://staging-log-api.newrelic.com/log/v1"
+    else if m.nrRegion = "JP" OR m.nrRegion = "jp"
+        return "https://log-api.jp.newrelic.com/log/v1"
     end if
 end function
 
@@ -1406,6 +1415,8 @@ function nrMetricApiUrl() as String
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
         return "https://staging-metric-api.newrelic.com/metric/v1"
+    else if m.nrRegion = "JP"
+        return "https://metric-api.jp.newrelic.com/metric/v1"
     end if
 end function
 

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -187,7 +187,7 @@ function nrMobileCollectorApiUrl() as String
     else if m.nrRegion = "EU" OR m.nrRegion = "eu"
         return "https://mobile-collector.eu01.nr-data.net/mobile/v4/connect"
     else if m.nrRegion = "JP" OR m.nrRegion = "jp"
-        return "https://mobile-collector.jp.nr-data.net/mobile/v4/connect"
+        return "https://mobile-collector.jp.nr-data.net/mobile/v5/connect"
     else if m.nrRegion = "staging"
             'NOTE: set address hosting the test server
             return "https://staging-mobile-collector.newrelic.com/mobile/v4/connect"
@@ -196,17 +196,22 @@ end function
 
 function nrConnect(appToken as string, body as object)
     jsonRequestBody = FormatJSON(body)
-    urlReq = CreateObject("roUrlTransfer")    
+    urlReq = CreateObject("roUrlTransfer")
     rport = CreateObject("roMessagePort")
-    urlReq.SetUrl(nrMobileCollectorApiUrl())
+    connectUrl = nrMobileCollectorApiUrl()
+    connectTime = nrTimestampFromDateTime(CreateObject("roDateTime")).toStr()
+    urlReq.SetUrl(connectUrl)
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)
     urlReq.EnableEncodings(true)
     urlReq.AddHeader("CONTENT-TYPE", "application/json")
     urlReq.AddHeader("X-App-License-Key", appToken)
-    urlReq.AddHeader("X-NewRelic-Connect-Time", nrTimestampFromDateTime(CreateObject("roDateTime")).toStr())
+    urlReq.AddHeader("X-NewRelic-Connect-Time", connectTime)
     urlReq.SetMessagePort(rport)
+    'print "=== nrConnect curl ==="
+    'print "curl -X POST '" + connectUrl + "' -H 'Content-Type: application/json' -H 'X-App-License-Key: " + appToken + "' -H 'X-NewRelic-Connect-Time: " + connectTime + "' -d '" + jsonRequestBody + "'"
+    'print "======================"
     urlReq.AsyncPostFromString(jsonRequestBody)
     
     msg = wait(10000, rport)

--- a/components/NewRelicAgent/NRTask.brs
+++ b/components/NewRelicAgent/NRTask.brs
@@ -146,14 +146,17 @@ return [dataToken,appInfo,0,[],[],[],[],[],{},videoSamples]
 end function
 
 function nrMobileCollectorApiUrl() as String
-    if m.nrRegion = "US" OR m.nrRegion = "us"
+    region = m.region
+    if region = invalid then region = m.top.region
+    if region = invalid then region = "US"
+    if region = "EU" OR region = "eu"
+        return "https://mobile-collector.eu01.nr-data.net/mobile/v3/data"
+    else if region = "staging"
+        'NOTE: set address hosting the test server
+        return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
+    else
         return "https://mobile-collector.newrelic.com/mobile/v3/data"
-    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
-        return "https://mobile-collector.eu.newrelic.com/mobile/v3/data"
-    else if m.nrRegion = "staging"
-            'NOTE: set address hosting the test server
-            return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
-        end if
+    end if
 end function
 
 function nrData(videoSamples)

--- a/components/NewRelicAgent/NRTask.brs
+++ b/components/NewRelicAgent/NRTask.brs
@@ -155,7 +155,7 @@ function nrMobileCollectorApiUrl() as String
         'NOTE: set address hosting the test server
         return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
     else if(region = "JP" OR region = "jp")
-       urlReq.SetUrl("https://mobile-collector.jp.nr-data.net/mobile/v3/data")
+       return "https://mobile-collector.jp.nr-data.net/mobile/v3/data"
     else
        return "https://mobile-collector.newrelic.com/mobile/v3/data"
     end if

--- a/components/NewRelicAgent/NRTask.brs
+++ b/components/NewRelicAgent/NRTask.brs
@@ -145,17 +145,27 @@ function getV3ReqBody(dataToken,videoSamples,appInfo)
 return [dataToken,appInfo,0,[],[],[],[],[],{},videoSamples]
 end function
 
+function nrMobileCollectorApiUrl() as String
+    if m.nrRegion = "US" OR m.nrRegion = "us"
+        return "https://mobile-collector.newrelic.com/mobile/v3/data"
+    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
+        return "https://mobile-collector.eu.newrelic.com/mobile/v3/data"
+    else if m.nrRegion = "staging"
+            'NOTE: set address hosting the test server
+            return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
+        end if
+end function
+
 function nrData(videoSamples)
     
     body = getV3ReqBody(m.top.dataToken,videoSamples, m.top.appInfo)
     jsonRequestBody = FormatJSON(body)
     urlReq = CreateObject("roUrlTransfer")    
     rport = CreateObject("roMessagePort")
-    if(m.region = "staging")
-        urlReq.SetUrl("https://staging-mobile-collector.newrelic.com/mobile/v3/data")
-    else 
-        urlReq.SetUrl("https://mobile-collector.newrelic.com/mobile/v3/data")
-    end if
+
+    url = box(nrMobileCollectorApiUrl())
+    urlReq.SetUrl(url)
+
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)

--- a/components/NewRelicAgent/NRTask.brs
+++ b/components/NewRelicAgent/NRTask.brs
@@ -154,8 +154,10 @@ function nrMobileCollectorApiUrl() as String
     else if region = "staging"
         'NOTE: set address hosting the test server
         return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
+    else if(region = "JP" OR region = "jp")
+       urlReq.SetUrl("https://mobile-collector.jp.nr-data.net/mobile/v3/data")
     else
-        return "https://mobile-collector.newrelic.com/mobile/v3/data"
+       return "https://mobile-collector.newrelic.com/mobile/v3/data"
     end if
 end function
 
@@ -165,10 +167,11 @@ function nrData(videoSamples)
     jsonRequestBody = FormatJSON(body)
     urlReq = CreateObject("roUrlTransfer")    
     rport = CreateObject("roMessagePort")
-
-    url = box(nrMobileCollectorApiUrl())
-    urlReq.SetUrl(url)
-
+    if(m.region = "staging")
+        urlReq.SetUrl("https://staging-mobile-collector.newrelic.com/mobile/v3/data")
+    else 
+        urlReq.SetUrl("https://mobile-collector.newrelic.com/mobile/v3/data")
+    end if
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)

--- a/components/NewRelicAgent/NRTask.brs
+++ b/components/NewRelicAgent/NRTask.brs
@@ -137,7 +137,7 @@ function nrSampleProcessor(sampleType as String, endpoint as String, appName as 
             end if
         end if
     else
-        print("-- nrSampleProcessor: m.nr is invalid!! --")
+        'print("-- nrSampleProcessor: m.nr is invalid!! --")
     end if
 end function
 
@@ -149,12 +149,12 @@ function nrMobileCollectorApiUrl() as String
     region = m.region
     if region = invalid then region = m.top.region
     if region = invalid then region = "US"
-    if region = "EU" OR region = "eu"
+    if region = "EU" OR region = "eu" then
         return "https://mobile-collector.eu01.nr-data.net/mobile/v3/data"
-    else if region = "staging"
+    else if region = "staging" then
         'NOTE: set address hosting the test server
         return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
-    else if(region = "JP" OR region = "jp")
+    else if region = "JP" OR region = "jp" then
        return "https://mobile-collector.jp.nr-data.net/mobile/v3/data"
     else
        return "https://mobile-collector.newrelic.com/mobile/v3/data"
@@ -162,26 +162,28 @@ function nrMobileCollectorApiUrl() as String
 end function
 
 function nrData(videoSamples)
-    
+
     body = getV3ReqBody(m.top.dataToken,videoSamples, m.top.appInfo)
     jsonRequestBody = FormatJSON(body)
-    urlReq = CreateObject("roUrlTransfer")    
+    urlReq = CreateObject("roUrlTransfer")
     rport = CreateObject("roMessagePort")
-    if(m.region = "staging")
-        urlReq.SetUrl("https://staging-mobile-collector.newrelic.com/mobile/v3/data")
-    else 
-        urlReq.SetUrl("https://mobile-collector.newrelic.com/mobile/v3/data")
-    end if
+
+    url = box(nrMobileCollectorApiUrl())
+    urlReq.SetUrl(url)
+
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)
     urlReq.EnableEncodings(true)
-   
+
     urlReq.AddHeader("CONTENT-TYPE", "application/json")
     urlReq.AddHeader("X-NewRelic-OS-Name","RokuOS")
     urlReq.AddHeader("X-App-License-Key", m.top.appToken)
     urlReq.AddHeader("X-NewRelic-App-Version","1.0")
     urlReq.SetMessagePort(rport)
+    'print "=== nrData curl ==="
+    'print "curl -X POST '" + url + "' -H 'Content-Type: application/json' -H 'X-NewRelic-OS-Name: RokuOS' -H 'X-App-License-Key: " + m.top.appToken + "' -H 'X-NewRelic-App-Version: 1.0' -d '" + jsonRequestBody + "'"
+    'print "==================="
 
     urlReq.AsyncPostFromString(jsonRequestBody)
     

--- a/components/VideoScene.brs
+++ b/components/VideoScene.brs
@@ -31,10 +31,10 @@ function nrRefUpdated()
     'NOTE: Uncomment ONE of the following setup calls
 
     'Setup the video player with AWS Elemental MediaTailor SSAI (default)
-    setupMediaTailorVideo()
+    ' setupMediaTailorVideo()
 
     'Setup the video player with a single video
-    ' setupSingleVideo()
+    setupSingleVideo()
 
     'Setup the video player with a playlist
     ' setupVideoPlaylist(true)

--- a/deploy.sh
+++ b/deploy.sh
@@ -24,7 +24,7 @@ touch timestamp
 zip -FS -9 -r out/bundle * -x run extras "*.log" "*.md" ".git/*" ".DS_Store" "out/*" "deploys/*"
 
 # deploy
-DEPLOY_RESULT=$(curl -f -sS --user rokudev:$2 --anyauth -F "mysubmit=Install" -F "archive=@out/bundle.zip" -F "passwd=" http://$ROKU_DEV_TARGET/plugin_install \
+DEPLOY_RESULT=$(curl -f -sS --user rokudev:$2 --digest -F "mysubmit=Install" -F "archive=@out/bundle.zip" -F "passwd=" http://$ROKU_DEV_TARGET/plugin_install \
 | python3 -c 'import sys, re; print("\n".join(re.findall("<font color=\"red\">(.*?)</font>", sys.stdin.read(), re.DOTALL)))')
 
 DEPLOY_STATUS=$?

--- a/source/NewRelicAgent.brs
+++ b/source/NewRelicAgent.brs
@@ -356,19 +356,20 @@ function nrSendSummaryMetric(nr as Object, name as String, interval as Integer, 
     nr.callFunc("nrSendSummaryMetric", name, interval, value, attr)
 end function
 
-' Activate QOE (Quality of Experience) tracking at runtime.
-' Note: Once enabled, QOE tracking cannot be disabled during the session.
+' Enable or disable QOE (Quality of Experience) tracking at runtime.
+' QOE tracking is ENABLED by default (since v4.2.1). Call with false to disable.
 '
 ' @param nr New Relic Agent object.
-function nrActivateQoeTracking(nr as Object) as Void
-    nr.callFunc("nrActivateQoeTracking", true)
+' @param enable Boolean — true to enable, false to disable. Default: true.
+function nrActivateQoeTracking(nr as Object, enable = true as Boolean) as Void
+    nr.callFunc("nrActivateQoeTracking", enable)
 end function
 
 ' Set the QOE aggregate interval multiplier.
 ' QOE events are sent every (harvest_time * multiplier) seconds.
 '
 ' @param nr New Relic Agent object.
-' @param multiplier Integer multiplier (min 1). Default 1.
+' @param multiplier Integer multiplier (min 1). Default 2.
 function nrSetQoeAggregateIntervalMultiplier(nr as Object, multiplier as Integer) as Void
     nr.callFunc("nrSetQoeAggregateIntervalMultiplier", multiplier)
 end function


### PR DESCRIPTION
Add Japan (JP) region endpoints for events, logs, metrics, connect, and data APIs. JP is now a valid region value alongside US, EU, and staging. Confirmed endpoints from platform team.