### PR TITLE
fix(ima): route ad events to VideoAdAction instead of VideoAction

### DIFF
--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -433,6 +433,24 @@ function nrSendVideoEvent(actionName as String, attr = invalid) as Void
 
 end function
 
+' Send an ad event, type VideoAdAction. Mirrors nrSendVideoEvent but routes
+' AD_* actions to the VideoAdAction data model. No QoE bookkeeping —
+' ad-scoped events must not be folded into content-scoped QoE windows.
+function nrSendVideoAdEvent(actionName as String, attr = invalid) as Void
+    if attr <> invalid then
+        print "[New Relic] Ad Event: " + actionName + " " + FormatJSON(attr)
+    else
+        print "[New Relic] Ad Event: " + actionName + " "
+    end if
+    ev = nrCreateEvent("VideoAdAction", actionName)
+    ev = nrAddVideoAttributes(ev)
+    ev = nrAddCustomAttributes(ev)
+    if type(attr) = "roAssociativeArray"
+       ev.Append(attr)
+    end if
+    nrRecordEvent(ev)
+end function
+
 function nrSendErrorEvent(actionName as String, attr as Dynamic) as Void
     ev = nrCreateEvent("VideoErrorAction", actionName)
     ev = nrAddVideoAttributes(ev)

--- a/components/NewRelicAgent/NRAgent.xml
+++ b/components/NewRelicAgent/NRAgent.xml
@@ -26,6 +26,7 @@
         <function name="nrAppStarted"/>
         <function name="nrSendSystemEvent"/>
         <function name="nrSendVideoEvent"/>
+        <function name="nrSendVideoAdEvent"/>
         <function name="nrSendErrorEvent"/>
         <function name="nrSendCustomEvent"/>
         <function name="nrSendHttpRequest"/>

--- a/components/NewRelicAgent/trackers/IMATracker.brs
+++ b/components/NewRelicAgent/trackers/IMATracker.brs
@@ -23,7 +23,7 @@ end sub
 '=========================='
 
 function nrSendIMAAdBreakStart(adBreakInfo as Object) as Void
-    m.top.nr.callFunc("nrSendVideoEvent", "AD_BREAK_START", nrIMAAttributes(adBreakInfo, invalid))
+    m.top.nr.callFunc("nrSendVideoAdEvent", "AD_BREAK_START", nrIMAAttributes(adBreakInfo, invalid))
     m.adState.timeSinceAdBreakBegin = m.nrTimer.TotalMilliseconds()
 end function
 
@@ -32,17 +32,17 @@ function nrSendIMAAdBreakEnd(adBreakInfo as Object) as Void
     timeSinceAdBreakBegin = m.nrTimer.TotalMilliseconds() - m.adState.timeSinceAdBreakBegin
     m.top.nr.callFunc("nrAddToTotalAdPlaytime", timeSinceAdBreakBegin)
     attr.AddReplace("timeSinceAdBreakBegin", timeSinceAdBreakBegin)
-    m.top.nr.callFunc("nrSendVideoEvent", "AD_BREAK_END", attr)
+    m.top.nr.callFunc("nrSendVideoAdEvent", "AD_BREAK_END", attr)
 end function
 
 function nrSendIMAAdStart(ad as Object) as Void
     m.adState.numberOfAds = m.adState.numberOfAds + 1
-    m.top.nr.callFunc("nrSendVideoEvent", "AD_START", nrIMAAttributes(ad.adBreakInfo, ad))
+    m.top.nr.callFunc("nrSendVideoAdEvent", "AD_START", nrIMAAttributes(ad.adBreakInfo, ad))
     m.adState.timeSinceAdStarted = m.nrTimer.TotalMilliseconds()
 end function
 
 function nrSendIMAAdEnd(ad as Object) as Void
-    m.top.nr.callFunc("nrSendVideoEvent", "AD_END", nrIMAAttributes(ad.adBreakInfo, ad))
+    m.top.nr.callFunc("nrSendVideoAdEvent", "AD_END", nrIMAAttributes(ad.adBreakInfo, ad))
     m.adState.timeSinceAdStarted = 0
 end function
 
@@ -63,7 +63,7 @@ function nrSendIMAAdError(error as Object) as Void
     if error.id <> invalid then attr.AddReplace("adErrorCode", error.id)
     if error.info <> invalid then attr.AddReplace("adErrorMsg", error.info)
     if error.type <> invalid then attr.AddReplace("adErrorType", error.type)
-    m.top.nr.callFunc("nrSendVideoEvent", "AD_ERROR", attr)
+    m.top.nr.callFunc("nrSendVideoAdEvent", "AD_ERROR", attr)
 end function
 
 '==================='
@@ -73,7 +73,7 @@ end function
 function nrSendIMAAdQuartile(ad as Object, quartile as Integer) as Void
     attr = nrIMAAttributes(ad.adBreakInfo, ad)
     attr.AddReplace("adQuartile", quartile)
-    m.top.nr.callFunc("nrSendVideoEvent", "AD_QUARTILE", attr)
+    m.top.nr.callFunc("nrSendVideoAdEvent", "AD_QUARTILE", attr)
 end function
 
 'TODO: totalAdPlaytime

--- a/source/NewRelicAgent.brs
+++ b/source/NewRelicAgent.brs
@@ -161,6 +161,16 @@ function nrSendVideoEvent(nr as Object, actionName as String, attr = invalid) as
     nr.callFunc("nrSendVideoEvent", actionName, attr)
 end function
 
+' Send an ad event, type VideoAdAction.
+'
+' @param nr New Relic Agent object.
+' @param actionName Action name (typically AD_BREAK_START / AD_START /
+'                   AD_QUARTILE / AD_END / AD_BREAK_END / AD_ERROR).
+' @param attr (optional) Attributes associative array.
+function nrSendVideoAdEvent(nr as Object, actionName as String, attr = invalid) as Void
+    nr.callFunc("nrSendVideoAdEvent", actionName, attr)
+end function
+
 ' Send an HTTP_REQUEST event of type ConnectedDeviceSystem.
 '
 ' @param nr New Relic Agent object.


### PR DESCRIPTION
IMATracker was emitting all six AD_* events through nrSendVideoEvent, which hard-codes the event type to "VideoAction". As a result, every Google IMA ad lifecycle event (AD_BREAK_START / AD_BREAK_END / AD_START / AD_END / AD_QUARTILE / AD_ERROR) was being recorded as a plain VideoAction instead of VideoAdAction, invisible to any NRQL query on the ad data model. It also dragged ad-scoped events through the content-scoped QoE handler.

Add nrSendVideoAdEvent(actionName, attr) — a direct analogue of nrSendVideoEvent that creates a VideoAdAction and skips QoE bookkeeping — expose it via NRAgent.xml and the public shim in source/NewRelicAgent.brs, and switch IMATracker's six call sites over to it.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## 📺 Roku Device Testing (Required)

Since Roku tests cannot be automated, manual testing on a physical Roku device is **required** for all PRs.

### Manual Testing Checklist

- [x] I have run tests on a physical Roku device
- [ ] All existing tests pass on the device
- [ ] New functionality (if any) has been manually verified
- [x] Video playback events are being tracked correctly

### Testing Evidence
<!-- Please provide screenshots, logs, or a detailed description of the manual testing performed -->

## Additional Context
<!-- Add any other context about the pull request here -->

## Related Issues
<!-- Link any related issues here using #issue_number -->

---
**Note:** A GitHub Action will post a reminder comment about manual testing requirements.
