### PR TITLE
chore(release): bump to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.2.0] - 2026/05/14
+
+### Added
+
+- AWS Elemental MediaTailor SSAI integration via Roku's RAFX_SSAI `awsemt` adapter. Each ad lifecycle event is recorded as a `VideoAdAction` (`AD_BREAK_START` / `AD_REQUEST` / `AD_START` / `AD_QUARTILE` / `AD_END` / `AD_BREAK_END` / `AD_ERROR`).
+- New public API `nrEnableMediaTailorTracking(nr, adIface)` to register New Relic listeners on a RAFX_SSAI adapter in one call, with no manual event forwarding required.
+- New public API `nrSetMediaTailorAdMetadata(tracker, metadata)` to inject sidecar key/value metadata that is appended to every subsequent `VideoAdAction`.
+- New public API `nrSendVideoAdEvent(nr, actionName, attr)` to record a `VideoAdAction` event directly. Companion to `nrSendVideoEvent` for ad-scoped events.
+- Sample MediaTailor integration (`components/MediaTailorTask.brs`, `components/VideoScene.brs`) demonstrating the recommended pattern: tracker created in the scene thread, session POST via `RAFX_SSAI.requestStream()`, and `position` field observe for ad-break resolution.
+
+### Fixed
+
+- Google IMA ad events (`AD_BREAK_START` / `AD_BREAK_END` / `AD_START` / `AD_END` / `AD_QUARTILE` / `AD_ERROR`) are now recorded as `VideoAdAction` instead of `VideoAction`. Previously, `IMATracker` routed all ad events through `nrSendVideoEvent`, hard-coding them to the content-video event type and making them invisible to NRQL queries on the ad data model.
+
 ## [4.1.2] - 2026/04/22
 
 ### Added

--- a/components/NewRelicAgent/NRAgent.xml
+++ b/components/NewRelicAgent/NRAgent.xml
@@ -13,7 +13,7 @@
 
 	<interface>
 		<!-- Properties -->
-        <field id="version" type="string" value="4.1.2"/>
+        <field id="version" type="string" value="4.2.0"/>
 		<!-- Public Methods (wrapped) -->
         <function name="NewRelicInit"/>
         <function name="NewRelicVideoStart"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-agent-roku",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "[![Community Project header](https://github.com/newrelic/open-source-office/raw/master/examples/categories/images/Community_Project.png)](https://github.com/newrelic/open-source-office/blob/master/examples/categories/index.md#community-project)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bump agent version 4.1.2 -> 4.2.0 in package.json and the NRAgent SceneGraph interface.

CHANGELOG entry covers what's shipped on top of 4.1.2:

Added
- AWS Elemental MediaTailor SSAI integration via Roku's RAFX_SSAI awsemt adapter; ad lifecycle events recorded as VideoAdAction.
- nrEnableMediaTailorTracking(nr, adIface) one-call listener registration.
- nrSetMediaTailorAdMetadata(tracker, metadata) sidecar metadata injection.
- nrSendVideoAdEvent(nr, actionName, attr) public API for direct VideoAdAction recording (companion to nrSendVideoEvent).
- Sample MediaTailor integration under components/MediaTailorTask.* and the setupMediaTailorVideo path in components/VideoScene.brs.

Fixed
- IMA ad lifecycle events now record as VideoAdAction instead of VideoAction. Previously every IMATracker event went through nrSendVideoEvent, which hard-coded VideoAction and made IMA ads invisible to ad-data-model NRQL.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## 📺 Roku Device Testing (Required)

Since Roku tests cannot be automated, manual testing on a physical Roku device is **required** for all PRs.

### Manual Testing Checklist

- [ ] I have run tests on a physical Roku device
- [ ] All existing tests pass on the device
- [ ] New functionality (if any) has been manually verified
- [ ] Video playback events are being tracked correctly

### Testing Evidence
<!-- Please provide screenshots, logs, or a detailed description of the manual testing performed -->

## Additional Context
<!-- Add any other context about the pull request here -->

## Related Issues
<!-- Link any related issues here using #issue_number -->

---
**Note:** A GitHub Action will post a reminder comment about manual testing requirements.
