### PR TITLE
fix: handle lowercase region input in endpoint URL resolution

### DIFF
--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -1349,9 +1349,9 @@ end function
 '       We could even pass an object containing different endpoints for events, metrics and logs.
 
 function nrEventApiUrl() as String
-    if m.nrRegion = "US"
+    if m.nrRegion = "US" OR m.nrRegion = "us"
         return "https://insights-collector.newrelic.com/v1/accounts/" + m.nrAccountNumber + "/events"
-    else if m.nrRegion = "EU"
+    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
         return "https://insights-collector.eu01.nr-data.net/v1/accounts/" + m.nrAccountNumber + "/events"
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
@@ -1360,9 +1360,9 @@ function nrEventApiUrl() as String
 end function
 
 function nrLogApiUrl() as String
-    if m.nrRegion = "US"
+    if m.nrRegion = "US" OR m.nrRegion = "us"
         return "https://log-api.newrelic.com/log/v1"
-    else if m.nrRegion = "EU"
+    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
         return "https://log-api.eu.newrelic.com/log/v1"
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server
@@ -1371,9 +1371,9 @@ function nrLogApiUrl() as String
 end function
 
 function nrMetricApiUrl() as String
-    if m.nrRegion = "US"
+    if m.nrRegion = "US" OR m.nrRegion = "us"
         return "https://metric-api.newrelic.com/metric/v1"
-    else if m.nrRegion = "EU"
+    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
         return "https://metric-api.eu.newrelic.com/metric/v1"
     else if m.nrRegion = "staging"
         'NOTE: set address hosting the test server

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -181,16 +181,23 @@ function NewRelicInit(account as String, apikey as String,appName as String, reg
     nrLog(["NewRelicInit complete. appName=", m.appName, ", region=", m.nrRegion, ", logging=", m.nrLogsState])
 end function
 
+function nrMobileCollectorApiUrl() as String
+    if m.nrRegion = "US" OR m.nrRegion = "us"
+        return "https://mobile-collector.newrelic.com/mobile/v3/data"
+    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
+        return "https://mobile-collector.eu.newrelic.com/mobile/v3/data"
+    else if m.nrRegion = "staging"
+            'NOTE: set address hosting the test server
+            return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
+        end if
+end function
 
 function nrConnect(appToken as string, body as object)
     jsonRequestBody = FormatJSON(body)
     urlReq = CreateObject("roUrlTransfer")    
     rport = CreateObject("roMessagePort")
-    if(m.nrRegion = "staging")
-        urlReq.SetUrl("https://staging-mobile-collector.newrelic.com/mobile/v4/connect")
-    else
-        urlReq.SetUrl("https://mobile-collector.newrelic.com/mobile/v4/connect")
-    end if
+    url = box(nrMobileCollectorApiUrl())
+    urlReq.SetUrl(url)
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)

--- a/components/NewRelicAgent/NRTask.brs
+++ b/components/NewRelicAgent/NRTask.brs
@@ -146,14 +146,17 @@ return [dataToken,appInfo,0,[],[],[],[],[],{},videoSamples]
 end function
 
 function nrMobileCollectorApiUrl() as String
-    if m.nrRegion = "US" OR m.nrRegion = "us"
+    region = m.region
+    if region = invalid then region = m.top.region
+    if region = invalid then region = "US"
+    if region = "EU" OR region = "eu"
+        return "https://mobile-collector.eu01.nr-data.net/mobile/v3/data"
+    else if region = "staging"
+        'NOTE: set address hosting the test server
+        return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
+    else
         return "https://mobile-collector.newrelic.com/mobile/v3/data"
-    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
-        return "https://mobile-collector.eu.newrelic.com/mobile/v3/data"
-    else if m.nrRegion = "staging"
-            'NOTE: set address hosting the test server
-            return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
-        end if
+    end if
 end function
 
 function nrData(videoSamples)

--- a/components/NewRelicAgent/NRTask.brs
+++ b/components/NewRelicAgent/NRTask.brs
@@ -145,17 +145,27 @@ function getV3ReqBody(dataToken,videoSamples,appInfo)
 return [dataToken,appInfo,0,[],[],[],[],[],{},videoSamples]
 end function
 
+function nrMobileCollectorApiUrl() as String
+    if m.nrRegion = "US" OR m.nrRegion = "us"
+        return "https://mobile-collector.newrelic.com/mobile/v3/data"
+    else if m.nrRegion = "EU" OR m.nrRegion = "eu"
+        return "https://mobile-collector.eu.newrelic.com/mobile/v3/data"
+    else if m.nrRegion = "staging"
+            'NOTE: set address hosting the test server
+            return "https://staging-mobile-collector.newrelic.com/mobile/v3/data"
+        end if
+end function
+
 function nrData(videoSamples)
     
     body = getV3ReqBody(m.top.dataToken,videoSamples, m.top.appInfo)
     jsonRequestBody = FormatJSON(body)
     urlReq = CreateObject("roUrlTransfer")    
     rport = CreateObject("roMessagePort")
-    if(m.region = "staging")
-        urlReq.SetUrl("https://staging-mobile-collector.newrelic.com/mobile/v3/data")
-    else 
-        urlReq.SetUrl("https://mobile-collector.newrelic.com/mobile/v3/data")
-    end if
+
+    url = box(nrMobileCollectorApiUrl())
+    urlReq.SetUrl(url)
+
     urlReq.RetainBodyOnError(true)
     urlReq.EnablePeerVerification(false)
     urlReq.EnableHostVerification(false)


### PR DESCRIPTION
Accept both "US"/"us" and "EU"/"eu" in nrEventApiUrl, nrLogApiUrl, and nrMetricApiUrl so the onboarding framework's auto-injected lowercase region value routes to the correct endpoint. "staging" is unchanged.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## 📺 Roku Device Testing (Required)

Since Roku tests cannot be automated, manual testing on a physical Roku device is **required** for all PRs.

### Manual Testing Checklist

- [ ] I have run tests on a physical Roku device
- [ ] All existing tests pass on the device
- [ ] New functionality (if any) has been manually verified
- [ ] Video playback events are being tracked correctly

### Testing Evidence
<!-- Please provide screenshots, logs, or a detailed description of the manual testing performed -->

## Additional Context
<!-- Add any other context about the pull request here -->

## Related Issues
<!-- Link any related issues here using #issue_number -->

---
**Note:** A GitHub Action will post a reminder comment about manual testing requirements.
