### PR TITLE
feat: enable QoE by default with interval multiplier 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,24 +515,29 @@ nrForceHarvestLogs(m.nr)
 
 ### QoE Tracking
 
-Quality of Experience tracking is **disabled by default**. Once enabled, it cannot be disabled during the session.
+Quality of Experience tracking is **enabled by default**. It sends `QOE_AGGREGATE` events containing startup time, rebuffering, bitrate, and error KPIs. The default interval multiplier is `2` (QoE evaluated every 2 harvest cycles).
 
-#### `nrActivateQoeTracking(nr)`
+To disable QoE tracking, call `nrActivateQoeTracking(nr, false)` after init or set the flag directly.
 
-Enable QoE tracking. Sends `QOE_AGGREGATE` events containing startup time, rebuffering, bitrate, and error KPIs.
+#### `nrActivateQoeTracking(nr, enable)`
+
+Enable or disable QoE tracking at runtime.
 
 ```brightscript
-m.nr = NewRelic("ACCOUNT_ID", "API_KEY", "APP_NAME", "APP_TOKEN")
-nrActivateQoeTracking(m.nr)
+' Disable QoE tracking
+nrActivateQoeTracking(m.nr, false)
+
+' Re-enable QoE tracking
+nrActivateQoeTracking(m.nr, true)
 ```
 
 #### `nrSetQoeAggregateIntervalMultiplier(nr, multiplier)`
 
-Control how often QoE events are sent. A multiplier of `N` sends QoE events every N harvest cycles. Default is `1`, minimum is `1`.
+Control how often QoE events are sent. A multiplier of `N` sends QoE events every N harvest cycles. Default is `2`, minimum is `1`.
 
 ```brightscript
-' QoE evaluated every 2 harvest cycles (e.g., every 120s with 60s harvest)
-nrSetQoeAggregateIntervalMultiplier(m.nr, 2)
+' QoE evaluated every 3 harvest cycles (e.g., every 180s with 60s harvest)
+nrSetQoeAggregateIntervalMultiplier(m.nr, 3)
 ```
 
 **QoE behavior notes:**

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -7,8 +7,8 @@
 
 sub init()
     m.nrLogsState = false
-    m.qoeTrackingEnabled = false  'Default disabled - must be explicitly enabled
-    m.qoeAggregateIntervalMultiplier = 1
+    m.qoeTrackingEnabled = true
+    m.qoeAggregateIntervalMultiplier = 2
     m.qoeHarvestCycleCounter = 0
     m.nrAgentVersion = m.top.version
     m.eventApiUrl = ""


### PR DESCRIPTION
Enables QoE tracking by default and sets the interval multiplier default to 2. Part of NR-573376.