### PR TITLE
fix: remove totalTimeSwitchedDown KPI and dedupe QOE state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Removed
+
+- Removed `totalTimeSwitchedDown` from the `QOE_AGGREGATE` event and its internal tracking (rendition-switch-down interval accumulation).
+
 ## [4.2.1] - 2026/05/26
 
 ### Added

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -165,7 +165,6 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | maxDownloadRate                 | Maximum network download bitrate in bits per second observed during content playback. Omitted if no sample was observed.                                                         |
 | totalSwitchUps                  | Count of rendition switches to a higher bitrate during content playback. Always emitted; 0 is a valid value.                                                                     |
 | totalSwitchDowns                | Count of rendition switches to a lower bitrate during content playback. Always emitted; 0 is a valid value.                                                                      |
-| totalTimeSwitchedDown           | Total milliseconds spent at a rendition below the session's all-time maximum. Always emitted; 0 is a valid value.                                                                |
 | totalPauseTime                  | Total milliseconds the user kept content paused. Always emitted; 0 is a valid value.                                                                                              |
 | totalRenditions             | Count of distinct rendition bitrates selected during content playback. Always emitted; 0 is a valid value.                                                                        |
 | qoeAggregateVersion      | Version identifier for QOE calculation algorithm. Currently "1.0.0".                                                                               |

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -264,53 +264,13 @@ function NewRelicVideoStart(videoObject as Object) as Void
     m.nrVideoCounter = 0
     m.nrNumberOfErrors = 0
 
-    'QOE (Quality of Experience) tracking fields
-    m.qoePeakBitrate = 0
-    m.qoeHadPlaybackFailure = false
-    m.qoeTotalRebufferingTime = 0
-    m.qoeBitrateSum = 0
-    m.qoeBitrateCount = 0
-    m.qoeLastTrackedBitrate = invalid
-    m.qoeStartupTime = invalid  'Cached startup time, calculated once per view session
-
-    'Startup time calculation fields - capture actual event timestamps
-    m.contentRequestTimestamp = invalid
-    m.contentStartTimestamp = invalid
-    m.contentErrorTimestamp = invalid  'Timestamp when content error occurred (for startup failures)
-    m.startupPeriodAdTime = 0  'Ad time that occurred during startup period
-    m.hasContentStarted = false  'Tracks whether content has successfully started (for buffer classification)
-
-    m.qoeCurrentBitrate = invalid
-    m.qoeLastRenditionChangeTime = invalid
-    m.qoeTotalBitrateWeightedTime = 0.0
-    m.qoeTotalActiveTime = 0
-    m.qoePlaybackActive = false
-
-    'QOE_AGGREGATE extension state
-    m.qoeDownloadRateSum = 0&
-    m.qoeDownloadRateCount = 0
-    m.qoeDownloadRateMin = invalid
-    m.qoeDownloadRateMax = 0&
-    'switch counters
-    m.qoeSwitchUps = 0
-    m.qoeSwitchDowns = 0
-    'Internal — anchors "switched-down"; not emitted
-    m.qoeMaxRendition = 0&
-    'time-weighted rendition state (ms timestamps)
-    m.qoeTimeSwitchedDown = 0&
-    m.qoeSwitchedDownSinceMs = invalid
-    'pause accumulator (ms timestamps)
-    m.qoeTotalPauseTime = 0&
-    m.qoePauseStartMs = invalid
-    'distinct rendition variants
-    m.qoePlayedRenditions = {}
-
-    'QOE: Harvest multiplier support
+    'QOE: Harvest multiplier support (session-lifetime — not part of the
+    'per-view state nrResetQoeMetrics() manages)
     m.qoeHarvestCycleCounter = 0  'Counter to track harvest cycles for multiplier logic
 
-    'QOE: Dirty checking support
-    m.qoeLastSentKpis = invalid  'Store last sent QOE KPIs to prevent redundant events
-    m.qoeFinalEventSent = false  'Track if final QOE was already sent for this session
+    'QOE (Quality of Experience) tracking fields — shares its field list with
+    'nrResetQoeMetrics(), which every subsequent view session runs through.
+    nrResetQoeMetrics()
 
     'Setup event listeners 
     m.nrVideoObject.observeFieldScoped("state", "nrStateObserver")
@@ -878,36 +838,36 @@ function nrAreQoeKpisEqual(currentKpis as Dynamic, lastSentKpis as Dynamic) as B
         return false  'No previous data to compare - send current QOE
     end if
 
-    'Compare core QOE KPIs (must all match to be considered equal)
-    'Using string conversion to handle potential type mismatches and rounding
-    currentStartupTime = toString(currentKpis.startupTime)
-    lastStartupTime = toString(lastSentKpis.startupTime)
+    'Every KPI field nrCalculateQOEKpiAttributes() can emit, compared by
+    'string to handle type mismatches/rounding. Fields it omits conditionally
+    '(e.g. avgDownloadRate when no sample arrived) read as invalid on either
+    'side and still compare correctly. qoeAggregateVersion is a constant, not
+    'a metric, so it is deliberately excluded.
+    qoeKpiFields = [
+        "startupTime",
+        "peakBitrate",
+        "hadStartupError",
+        "hadPlaybackError",
+        "totalRebufferingTime",
+        "rebufferingRatio",
+        "totalPlaytime",
+        "averageBitrate",
+        "avgDownloadRate",
+        "minDownloadRate",
+        "maxDownloadRate",
+        "totalSwitchUps",
+        "totalSwitchDowns",
+        "totalPauseTime",
+        "totalRenditions"
+    ]
 
-    currentAvgBitrate = toString(currentKpis.averageBitrate)
-    lastAvgBitrate = toString(lastSentKpis.averageBitrate)
+    for each field in qoeKpiFields
+        if toString(currentKpis[field]) <> toString(lastSentKpis[field])
+            return false
+        end if
+    end for
 
-    currentPeakBitrate = toString(currentKpis.peakBitrate)
-    lastPeakBitrate = toString(lastSentKpis.peakBitrate)
-
-    currentRebufferRatio = toString(currentKpis.rebufferingRatio)
-    lastRebufferRatio = toString(lastSentKpis.rebufferingRatio)
-
-    currentTotalRebufferTime = toString(currentKpis.totalRebufferingTime)
-    lastTotalRebufferTime = toString(lastSentKpis.totalRebufferingTime)
-
-    currentTotalPlaytime = toString(currentKpis.totalPlaytime)
-    lastTotalPlaytime = toString(lastSentKpis.totalPlaytime)
-
-    'Error flags
-    currentStartupError = toString(currentKpis.hadStartupError)
-    lastStartupError = toString(lastSentKpis.hadStartupError)
-
-    currentPlaybackError = toString(currentKpis.hadPlaybackError)
-    lastPlaybackError = toString(lastSentKpis.hadPlaybackError)
-
-    areEqual = (currentStartupTime = lastStartupTime and currentAvgBitrate = lastAvgBitrate and currentPeakBitrate = lastPeakBitrate and currentRebufferRatio = lastRebufferRatio and currentTotalRebufferTime = lastTotalRebufferTime and currentTotalPlaytime = lastTotalPlaytime and currentStartupError = lastStartupError and currentPlaybackError = lastPlaybackError)
-
-    return areEqual
+    return true
 end function
 
 function toString(value as Dynamic) as String
@@ -1641,8 +1601,8 @@ function nrSendBackupVideoEnd() as Void
     'playlist item BEFORE the backup CONTENT_END mutates QOE state. Without
     'this, qoeFinalEventSent stays false, the next item's nrSendRequest skips
     'nrResetQoeMetrics(), and every m.qoe* accumulator (totalPauseTime,
-    'totalSwitchUps/Downs, totalTimeSwitchedDown, qoeMaxRendition,
-    'qoePlayedRenditions, etc.) carries across the playlist boundary.
+    'totalSwitchUps/Downs, qoePlayedRenditions, etc.) carries across the
+    'playlist boundary.
     nrQoeOnViewEnd()
     nrGenerateQoeEvent(true)
     nrSendBackupVideoEvent("CONTENT_END")
@@ -2857,8 +2817,6 @@ function nrQoeOnContentStart(bitrate as Dynamic) as Void
     'that would not match the same integer value seen later.
     intBitrate = Int(bitrate)
     m.qoePlayedRenditions[intBitrate.ToStr()] = true
-    m.qoeMaxRendition = intBitrate
-    'm.qoeSwitchedDownSinceMs stays invalid — we have not gone down yet.
 end function
 
 function nrTrackDownloadRateForQoe(rate as Dynamic) as Void
@@ -2910,25 +2868,6 @@ function nrQoeOnRenditionChange(shift as String, newBitrate as Dynamic) as Void
     if shift = "down" then m.qoeSwitchDowns = m.qoeSwitchDowns + 1
 
     m.qoePlayedRenditions[intNewBitrate.ToStr()] = true
-
-    prevWasReduced = (m.qoeSwitchedDownSinceMs <> invalid)
-    t = m.nrTimer.TotalMilliseconds()
-
-    '1. Close any open reduced interval if recovering to max or higher
-    if prevWasReduced and intNewBitrate >= m.qoeMaxRendition
-        m.qoeTimeSwitchedDown = m.qoeTimeSwitchedDown + (t - m.qoeSwitchedDownSinceMs)
-        m.qoeSwitchedDownSinceMs = invalid
-    end if
-
-    '2. Bump the all-time max (internal only — defines "below max")
-    if intNewBitrate > m.qoeMaxRendition
-        m.qoeMaxRendition = intNewBitrate
-    end if
-
-    '3. Open a reduced interval if below the current max
-    if intNewBitrate < m.qoeMaxRendition and m.qoeSwitchedDownSinceMs = invalid
-        m.qoeSwitchedDownSinceMs = t
-    end if
 end function
 
 function nrQoeOnPause() as Void
@@ -2954,11 +2893,6 @@ function nrQoeOnViewEnd() as Void
     if m.qoePauseStartMs <> invalid
         m.qoeTotalPauseTime = m.qoeTotalPauseTime + (t - m.qoePauseStartMs)
         m.qoePauseStartMs = invalid
-    end if
-
-    if m.qoeSwitchedDownSinceMs <> invalid
-        m.qoeTimeSwitchedDown = m.qoeTimeSwitchedDown + (t - m.qoeSwitchedDownSinceMs)
-        m.qoeSwitchedDownSinceMs = invalid
     end if
 end function
 
@@ -3051,13 +2985,6 @@ function nrCalculateQOEKpiAttributes() as Object
     'switch counters (always emit; 0 is a valid signal)
     kpiAttributes["totalSwitchUps"] = m.qoeSwitchUps
     kpiAttributes["totalSwitchDowns"] = m.qoeSwitchDowns
-
-    'switched-down timer (snapshot, do not mutate)
-    snapTimeReduced = m.qoeTimeSwitchedDown
-    if m.qoeSwitchedDownSinceMs <> invalid
-        snapTimeReduced = snapTimeReduced + (t - m.qoeSwitchedDownSinceMs)
-    end if
-    kpiAttributes["totalTimeSwitchedDown"] = snapTimeReduced
 
     'pause accumulator (snapshot, do not mutate)
     snapPause = m.qoeTotalPauseTime
@@ -3184,9 +3111,6 @@ function nrResetQoeMetrics() as Void
     m.qoeDownloadRateMax = 0&
     m.qoeSwitchUps = 0
     m.qoeSwitchDowns = 0
-    m.qoeMaxRendition = 0&
-    m.qoeTimeSwitchedDown = 0&
-    m.qoeSwitchedDownSinceMs = invalid
     m.qoeTotalPauseTime = 0&
     m.qoePauseStartMs = invalid
     m.qoePlayedRenditions = {}


### PR DESCRIPTION
## Description

Removes the `totalTimeSwitchedDown` KPI from the `QOE_AGGREGATE` event (data model change requested for the 1.1 QoE cleanup) and refactors two repetitive spots in the QOE code found while reviewing the removal:

- **Removed `totalTimeSwitchedDown`**: dropped from `QOE_AGGREGATE`, along with its internal switched-down-interval tracking (`m.qoeMaxRendition`, `m.qoeTimeSwitchedDown`, `m.qoeSwitchedDownSinceMs`) in `nrQoeOnContentStart`, `nrQoeOnRenditionChange`, `nrQoeOnViewEnd`, `nrCalculateQOEKpiAttributes`, and `nrResetQoeMetrics`. `totalSwitchUps`/`totalSwitchDowns` and rendition-variant tracking are untouched.
- **Deduplicated per-view QOE state reset**: init previously repeated ~30 lines of `m.qoe*` defaults that already existed in `nrResetQoeMetrics()`. Init now just calls `nrResetQoeMetrics()` (keeping the session-lifetime `qoeHarvestCycleCounter` separate), so there's one field list to maintain instead of two that can silently drift.
- **Fixed `nrAreQoeKpisEqual` dirty-check gap**: it only ever compared 8 legacy KPIs and never looked at the 1.1 additions (`avgDownloadRate`, `minDownloadRate`, `maxDownloadRate`, `totalSwitchUps`, `totalSwitchDowns`, `totalPauseTime`, `totalRenditions`). That meant `QOE_AGGREGATE` events stopped being sent after the first one whenever *only* a 1.1 KPI changed — most visibly during a long pause, where `totalPauseTime` is the only value still moving. Rewrote the 8 near-identical comparison stanzas into a loop over one `qoeKpiFields` list that now covers all emitted KPIs.

Also updated `CHANGELOG.md` (`[Unreleased] / Removed`) and `DATAMODEL.md` to drop the `totalTimeSwitchedDown` row.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)

> Marked as breaking: any consumer dashboards/queries reading `totalTimeSwitchedDown` off `QOE_AGGREGATE` will stop receiving it.

## 📺 Roku Device Testing (Required)

### Manual Testing Checklist

- [ ] I have run tests on a physical Roku device
- [ ] All existing tests pass on the device
- [ ] New functionality (if any) has been manually verified
- [ ] Video playback events are being tracked correctly