### PR TITLE
fix: MediaTailor SSAI live playback and session tracking

### DIFF
--- a/components/MediaTailorTask.brs
+++ b/components/MediaTailorTask.brs
@@ -13,10 +13,11 @@
 '   videoNode    – the Video SceneGraph node that will play the stream
 '   nr           – the New Relic Agent node (from NewRelic())
 '   tracker      – a MediaTailorTracker node created in the scene thread
-'   streamUrl    – MediaTailor session-init URL (VOD HLS POST target)
+'   streamUrl    – either an explicit session-init URL (POST /v1/session/...)
+'                  or an implicit-session "Playback URL" (GET /v1/master/...)
 '
 ' Optional node fields:
-'   streamType   – "VOD" (default). LIVE is reserved for future use.
+'   streamType   – "VOD" (default) or "LIVE".
 '   streamFormat – "hls" (default).
 '
 ' Copyright 2024 New Relic Inc. All Rights Reserved.
@@ -72,17 +73,51 @@ function mediaTailorTaskMain() as Void
     nrEnableMediaTailorTracking(m.top.nr, adIface)
 
     ' ---------------------------------------------------------------
-    ' 3. Session initialisation via RAFX_SSAI requestStream() for VOD.
-    '    Returns { manifest_url, tracking_url } on success.
+    ' 3. Session initialisation.
+    '    Also required for LIVE: this is what creates adIface's
+    '    internal loader (m.loader) - skipping it crashes enableAds()
+    '    later with "Array operation attempted on variable not DIM'd".
     ' ---------------------------------------------------------------
     playUrl = m.top.streamUrl
     nrMTTaskLog("initial playUrl = " + playUrl)
 
-    if streamType = "VOD"
+    if Instr(1, m.top.streamUrl, "/v1/master/") > 0
+        ' Implicit-session URL (the console "Playback URL"): AWS mints a
+        ' brand-new MediaTailor session on every single GET to this URL.
+        ' requestStream() below would resolve one session while the video
+        ' player, fetching the same static URL itself, resolves a totally
+        ' different one - so tracking would never match what's playing.
+        ' Resolve the session ourselves exactly once, then hand the player
+        ' that session-scoped manifest URL directly.
+        session = nrMTResolveMediaTailorSession(m.top.streamUrl)
+        if session <> invalid and session.manifestUrl <> ""
+            playUrl = session.manifestUrl
+            nrMTTaskLog("resolved MediaTailor session " + session.sessionId + " -> " + playUrl)
+            adIface.setStreamInfo({tracking_url: session.trackingUrl, manifest_url: session.manifestUrl, type: adIface.StreamType.LIVE})
+            nrMTTaskLog("tracking_url (best-effort, verify above) = " + session.trackingUrl)
+
+            sidecar = {adTrackingUrl: session.trackingUrl}
+            if m.nrMTTracker <> invalid
+                nrSetMediaTailorAdMetadata(m.nrMTTracker, sidecar)
+            end if
+        else
+            nrMTTaskLog("ERROR - could not resolve MediaTailor session from " + m.top.streamUrl + " - playing directly, no ad tracking")
+            if m.nrMTTracker <> invalid
+                errorCtx = {event: "Error", adErrorMsg: "could not resolve MediaTailor session", adErrorType: "session_init"}
+                m.nrMTTracker.callFunc("nrTrackMediaTailorEvent", "Error", errorCtx)
+            end if
+        end if
+    else if streamType = "VOD" or streamType = "LIVE"
+        ' Explicit session-init URL (POST /v1/session/.../<manifestName>).
         nrMTTaskLog("requesting stream via RAFX_SSAI awsemt")
 
+        ssaiStreamType = adIface.StreamType.VOD
+        if streamType = "LIVE"
+            ssaiStreamType = adIface.StreamType.LIVE
+        end if
+
         streamRequest = {
-            type: adIface.StreamType.VOD,
+            type: ssaiStreamType,
             url:  m.top.streamUrl,
             body: "{}"
         }
@@ -115,7 +150,6 @@ function mediaTailorTaskMain() as Void
                 errMsg = errMsg + " - " + formatjson(result.error)
             end if
             nrMTTaskLog(errMsg)
-            ' Surface the session-init failure as an AD_ERROR so New Relic captures it
             if m.nrMTTracker <> invalid
                 errorCtx = {event: "Error", adErrorMsg: errMsg, adErrorType: "session_init"}
                 m.nrMTTracker.callFunc("nrTrackMediaTailorEvent", "Error", errorCtx)
@@ -132,6 +166,7 @@ function mediaTailorTaskMain() as Void
     vidContent.url          = playUrl
     vidContent.title        = "MediaTailor Stream"
     vidContent.streamformat = streamFormat
+    vidContent.live         = (streamType = "LIVE")
 
     m.top.videoNode.content = vidContent
     m.top.videoNode.visible = true
@@ -179,7 +214,105 @@ function mediaTailorTaskMain() as Void
 end function
 
 function nrMTTaskLog(msg as String) as Void
-    if m.top.nr <> invalid and m.top.nr.callFunc("nrCheckLoggingState", {}) = true
+    if m.top.nr <> invalid and m.top.nr.callFunc("nrCheckLoggingState") = true
         print "MediaTailorTask: " + msg
     end if
+end function
+
+' Fetches a MediaTailor implicit-session URL (the console "Playback URL")
+' exactly once, and extracts the session ID AWS mints for that specific
+' request from the returned master playlist's variant paths, e.g.
+'   ../../../manifest/<hash>/<config>/<sessionId>/0.m3u8
+' Returns {sessionId, manifestUrl, trackingUrl} or invalid on failure.
+' manifestUrl is the resolved, session-scoped media playlist - hand this
+' to the player directly so it doesn't re-fetch the static URL itself
+' (which would mint a different, untracked session).
+' trackingUrl is a best-effort guess at AWS's convention (swap the
+' "manifest" path segment for "tracking", same session ID) - verified
+' with one extra GET, logged either way so this can be corrected later.
+function nrMTResolveMediaTailorSession(masterUrl as String) as Object
+    xfer = CreateObject("roUrlTransfer")
+    port = CreateObject("roMessagePort")
+    xfer.SetMessagePort(port)
+    xfer.SetUrl(masterUrl)
+    xfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
+    xfer.InitClientCertificates()
+    xfer.AddHeader("Accept", "application/vnd.apple.mpegurl, application/x-mpegURL, */*")
+    xfer.AsyncGetToString()
+
+    msg = wait(8000, port)
+    if msg = invalid or type(msg) <> "roUrlEvent" or msg.GetResponseCode() <> 200
+        return invalid
+    end if
+
+    variantPath = ""
+    for each line in msg.GetString().Split(chr(10))
+        trimmed = line.Trim()
+        if trimmed <> "" and trimmed.Left(1) <> "#"
+            variantPath = trimmed
+            exit for
+        end if
+    end for
+    if variantPath = "" then return invalid
+
+    manifestUrl = nrMTResolveRelativeUrl(masterUrl, variantPath)
+    pathSegments = manifestUrl.Split("/")
+    if pathSegments.Count() < 2 then return invalid
+    sessionId = pathSegments[pathSegments.Count() - 2]
+
+    trackingSegments = []
+    for i = 0 to pathSegments.Count() - 2
+        seg = pathSegments[i]
+        if seg = "manifest" then seg = "tracking"
+        trackingSegments.push(seg)
+    end for
+    trackingUrl = trackingSegments.Join("/")
+
+    nrMTTaskLog("[verify] GET " + trackingUrl)
+    verifyXfer = CreateObject("roUrlTransfer")
+    verifyPort = CreateObject("roMessagePort")
+    verifyXfer.SetMessagePort(verifyPort)
+    verifyXfer.SetUrl(trackingUrl)
+    verifyXfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
+    verifyXfer.InitClientCertificates()
+    verifyXfer.AddHeader("Accept", "application/json")
+    verifyXfer.AsyncGetToString()
+    verifyMsg = wait(8000, verifyPort)
+    if verifyMsg = invalid or type(verifyMsg) <> "roUrlEvent"
+        nrMTTaskLog("[verify] no response")
+    else
+        nrMTTaskLog("[verify] response code = " + verifyMsg.GetResponseCode().toStr() + " body head = " + Left(verifyMsg.GetString(), 300))
+    end if
+
+    return {sessionId: sessionId, manifestUrl: manifestUrl, trackingUrl: trackingUrl}
+end function
+
+' Resolves a relative HLS playlist path (e.g. "../../../manifest/a/b/0.m3u8")
+' against the absolute URL it was found in, per standard "../" directory
+' navigation. Query strings on baseUrl are dropped, not carried over.
+function nrMTResolveRelativeUrl(baseUrl as String, relativePath as String) as String
+    schemeSplit = baseUrl.Split("://")
+    scheme = schemeSplit[0]
+    rest = schemeSplit[1]
+
+    qIdx = Instr(1, rest, "?")
+    if qIdx > 0 then rest = rest.Left(qIdx - 1)
+
+    restSegments = rest.Split("/")
+    host = restSegments[0]
+
+    dirSegments = []
+    for i = 1 to restSegments.Count() - 2
+        dirSegments.push(restSegments[i])
+    end for
+
+    for each seg in relativePath.Split("/")
+        if seg = ".."
+            if dirSegments.Count() > 0 then dirSegments.Delete(dirSegments.Count() - 1)
+        else
+            dirSegments.push(seg)
+        end if
+    end for
+
+    return scheme + "://" + host + "/" + dirSegments.Join("/")
 end function

--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -1632,6 +1632,9 @@ function nrAddVideoAttributes(ev as Object) as Object
     ev.AddReplace("contentPlayhead", m.nrVideoObject.position * 1000)
     ev.AddReplace("contentIsMuted", m.nrVideoObject.mute)
     ev.AddReplace("contentIsFullscreen","true")
+    if m.nrVideoObject.content <> invalid and m.nrVideoObject.content.live <> invalid
+        ev.AddReplace("contentIsLive", m.nrVideoObject.content.live)
+    end if
     streamUrl = nrGenerateStreamUrl()
     ev.AddReplace("contentSrc", streamUrl)
     'Generate Id from Src (hashing it)

--- a/components/NewRelicAgent/trackers/MediaTailorTracker.brs
+++ b/components/NewRelicAgent/trackers/MediaTailorTracker.brs
@@ -212,7 +212,7 @@ end function
 ' Gate all debug output behind the NRAgent logging state (nrActivateLogging / nrEnableLogging).
 ' Only prints when the app has explicitly enabled NR logging.
 function nrMTLog(msg as String) as Void
-    if m.top.nr <> invalid and m.top.nr.callFunc("nrCheckLoggingState", {}) = true
+    if m.top.nr <> invalid and m.top.nr.callFunc("nrCheckLoggingState") = true
         print "MediaTailorTracker: " + msg
     end if
 end function

--- a/components/VideoScene.brs
+++ b/components/VideoScene.brs
@@ -241,10 +241,10 @@ function setupMediaTailorVideo() as Void
     m.video.notificationinterval = 1
 
     '----------------------------------------------------------------
-    ' MediaTailor session-init URL  ← REPLACE with your real URL
+    ' MediaTailor session-init URL
     ' VOD HLS: /v1/session/<hash>/<config>/hls  or  /v1/master/<hash>/<config>
     '----------------------------------------------------------------
-    mediaTailorUrl = "https://<account-id>.mediatailor.<region>.amazonaws.com/v1/session/<hash>/<config>/hls"
+    mediaTailorUrl = "https://<your-cloudfront-domain>.cloudfront.net/v1/master/<config-hash>/<playbackConfigName>/index.m3u8"
 
     '----------------------------------------------------------------
     ' Launch the background task that owns the SSAI adapter lifecycle.
@@ -256,7 +256,7 @@ function setupMediaTailorVideo() as Void
     m.mediaTailorTask.setField("nr",           m.nr)
     m.mediaTailorTask.setField("tracker",      MediaTailorTracker(m.nr))
     m.mediaTailorTask.setField("streamUrl",    mediaTailorUrl)
-    m.mediaTailorTask.setField("streamType",   "VOD")
+    m.mediaTailorTask.setField("streamType",   "LIVE")
     m.mediaTailorTask.setField("streamFormat", "hls")
     m.mediaTailorTask.control = "RUN"
 end function

--- a/source/MediaTailorTrackerInterface.brs
+++ b/source/MediaTailorTrackerInterface.brs
@@ -26,6 +26,7 @@ function nrEnableMediaTailorTracking(nr as Object, adIface as Object) as Void
     else
         m.nrMTTracker = MediaTailorTracker(nr)
     end if
+    adIface.addEventListener(adIface.AdEvent.PODS,            nrMTPodsListener)
     adIface.addEventListener(adIface.AdEvent.POD_START,      nrMTEventListener)
     adIface.addEventListener(adIface.AdEvent.IMPRESSION,     nrMTEventListener)
     adIface.addEventListener(adIface.AdEvent.FIRST_QUARTILE, nrMTEventListener)
@@ -43,6 +44,15 @@ function nrMTEventListener(adInfo as Object) as Void
     evtType = ""
     if adInfo.event <> invalid then evtType = adInfo.event
     m.nrMTTracker.callFunc("nrTrackMediaTailorEvent", evtType, adInfo)
+end function
+
+' Fires whenever RAFX_SSAI (re)parses the manifest and reports how many ad
+' pods it found - the fastest way to tell "no ad markers in this manifest"
+' apart from "ads detected but not rendering".
+function nrMTPodsListener(adInfo as Object) as Void
+    count = 0
+    if adInfo <> invalid and adInfo.adPods <> invalid then count = adInfo.adPods.Count()
+    print "MediaTailorTask: PodsFound - adPods.Count() = " + count.toStr()
 end function
 
 ' Create and return a new MediaTailorTracker node wired to the NRAgent.


### PR DESCRIPTION
## Summary
- Support LIVE stream type in `MediaTailorTask` (previously VOD-only; hitting a LIVE stream crashed on a missing `m.loader` init inside the RAFX_SSAI adapter)
- Resolve MediaTailor implicit-session "Playback URL"s (`/v1/master/...`) ourselves before handing playback to the video node, so the player and the ad tracker resolve to the *same* MediaTailor session instead of each independently minting an unrelated one
- Fix a `nrCheckLoggingState` call-arity bug (extra `{}` arg) that silently no-op'd all MediaTailor debug logging via `callFunc`
- Add a `PodsFound` listener for ad-pod-detection visibility during debugging
- Add `contentIsLive` to the standard VideoAction attribute set, sourced from the native `ContentNode.live` field (per the [video-core-js data model](https://github.com/newrelic/video-core-js/blob/master/DATAMODEL.md))

## Test plan
- [x] Deployed to a Roku device against a live MediaTailor SSAI stream
- [x] Confirmed no crash on LIVE stream type (previously `Array operation attempted on variable not DIM'd`)
- [x] Confirmed MediaTailor debug logs now print (previously silently suppressed)
- [x] Confirmed resolved session ID matches between playback URL and tracking URL (`[verify]` log against the tracking endpoint returned 200 with valid avails schema)
- [x] Confirmed full `AD_*` event lifecycle reaches New Relic (`AD_BREAK_START` → `AD_REQUEST` → `AD_START` → `AD_QUARTILE` ×2 → `AD_END`) with correct `adPodId`/`adtrackingurl` metadata
- [x] Confirmed `contentIsLive` appears on `VideoAction` events when `ContentNode.live` is set
