### PR TITLE
chore: align release notes and changelog format with docs template

### DIFF
--- a/.github/workflows/release-notes-docs-pr.yml
+++ b/.github/workflows/release-notes-docs-pr.yml
@@ -31,6 +31,9 @@ jobs:
     name: Update public docs
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -42,20 +45,24 @@ jobs:
 
       - name: Resolve release tag and body
         id: release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             tag="${{ github.event.inputs.tag }}"
           else
             tag="${{ github.event.release.tag_name }}"
           fi
-          body=$(gh release view "${tag}" --repo ${{ env.AGENT_REPO }} --json body --jq '.body')
           version="${tag#v}"
-          releaseDate=$(gh api "repos/${{ env.AGENT_REPO }}/contents/CHANGELOG.md" --jq '.content' | \
-            base64 -d | \
-            grep -m1 "^## \[${version}\]" | \
+          releaseDate=$(grep -m1 "^## \[${version}\]" CHANGELOG.md | \
             grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}')
+          body=$(awk -v ver="${version}" '
+            found && /^## +\[|^# / { exit }
+            found { print }
+            $0 ~ ("^## +\\[" ver "\\]") { found=1 }
+          ' CHANGELOG.md | sed -E 's/ *\(\[[0-9a-f]{6,40}\]\([^)]*\)\) *$//')
+          body=$(printf '%s' "${body}" | sed '/[^[:space:]]/,$!d' | sed -e :a -e '/^[[:space:]]*$/{$d;N;ba}')
+          if [[ -z "${body}" ]]; then
+            body="_No new features, improvements, or bug fixes for this release._"
+          fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "releaseDate=${releaseDate}" >> "$GITHUB_OUTPUT"
           echo "body<<RELEASE_BODY_EOF" >> "$GITHUB_OUTPUT"
@@ -97,11 +104,6 @@ jobs:
         env:
           RELEASE_BODY: ${{ steps.release.outputs.body }}
         run: |
-          processed=$(printf '%s\n' "${RELEASE_BODY}" | \
-            tr -d '\r' | \
-            awk 'BEGIN{s=1} /^## /{s=0} !s{print}' | \
-            sed "s/## What's Changed/## What's changed/g; s/## Full Changelog/## Full changelog/g" | \
-            awk '/^## Full changelog/{fc=1;next} fc && /^https?:\/\//{printf "[Full changelog](%s)\n\n",$0;fc=0;next} fc && NF==0{next} {fc=0;print}')
           echo "=== DRY RUN: MDX file that would be created ==="
           echo "File: ${{ steps.mdx.outputs.releaseFile }}"
           echo ""
@@ -114,7 +116,7 @@ jobs:
           printf '%s\n' 'category: ${{ env.AGENT_NAME }}'
           printf '%s\n' '---'
           printf '\n'
-          printf '%s\n' "${processed}"
+          printf '%s\n' "${RELEASE_BODY}"
 
       - name: Write release notes and open PR
         if: ${{ github.event.inputs.dry_run != 'true' }}
@@ -135,12 +137,6 @@ jobs:
             exit 0
           fi
 
-          processed=$(printf '%s\n' "${RELEASE_BODY}" | \
-            tr -d '\r' | \
-            awk 'BEGIN{s=1} /^## /{s=0} !s{print}' | \
-            sed "s/## What's Changed/## What's changed/g; s/## Full Changelog/## Full changelog/g" | \
-            awk '/^## Full changelog/{fc=1;next} fc && /^https?:\/\//{printf "[Full changelog](%s)\n\n",$0;fc=0;next} fc && NF==0{next} {fc=0;print}')
-
           {
             printf '%s\n' '---'
             printf '%s\n' 'subject: ${{ env.AGENT_SUBJECT }}'
@@ -151,7 +147,7 @@ jobs:
             printf '%s\n' 'category: ${{ env.AGENT_NAME }}'
             printf '%s\n' '---'
             printf '\n'
-            printf '%s\n' "${processed}"
+            printf '%s\n' "${RELEASE_BODY}"
           } > "${releaseFile}"
 
           git checkout -b "${branchName}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [4.2.2] - 2026-08-05
 
-### Added
+### New features
 
 - Added `"JP"` as a supported `region` value (alongside `"US"`, `"EU"`, and `"staging"`), routing event, log, metric, and mobile-connect traffic to the New Relic Japan collector endpoints. Region matching is case-insensitive (`"JP"` or `"jp"`).
 
-### Removed
-
-- Removed `totalTimeSwitchedDown` from the `QOE_AGGREGATE` event and its internal tracking (rendition-switch-down interval accumulation).
-
-### Fixed
+### Bug fixes
 
 - Fixed a dirty-check gap where `QOE_AGGREGATE` events stopped being sent after the first one whenever only a KPI added in 4.2.1 (`avgDownloadRate`, `minDownloadRate`, `maxDownloadRate`, `totalSwitchUps`, `totalSwitchDowns`, `totalPauseTime`, `totalRenditions`) changed between harvests — most noticeable during a long pause, where `totalPauseTime` was the only value still moving.
+
+### Notes
+
+- Removed `totalTimeSwitchedDown` from the `QOE_AGGREGATE` event and its internal tracking (rendition-switch-down interval accumulation).
 
 ## [4.2.1] - 2026/05/26
 


### PR DESCRIPTION
## Summary
- `release-notes-docs-pr.yml`: extracts a version's notes directly from `CHANGELOG.md` (stripping commit-hash links) instead of `gh release view`/`gh api` calls against GitHub's auto-generated release, with a fallback message when a version isn't found.
- Rewrites the v4.2.2 `CHANGELOG.md` entry to the `New features`/`Bug fixes`/`Notes` docs-template headings (same content, remapped from `Added`/`Fixed`/`Removed`).

This repo doesn't use semantic-release (no `.releaserc.json`, no `release-publish.yml` — releases are created manually), so the fix here is scoped to just this workflow file and the changelog entry, unlike the equivalent fix in the streaming-browser-agent repos (e.g. newrelic/video-html5-js#69).

## Test plan
- [ ] Run `release-notes-docs-pr.yml` with `dry_run: true` and confirm the printed MDX matches the CHANGELOG.md v4.2.2 entry