### PR TITLE
chore: use lowercase 'others' in AGENT_SUBJECT per docs team taxonomy

### DIFF
--- a/.github/workflows/release-notes-docs-pr.yml
+++ b/.github/workflows/release-notes-docs-pr.yml
@@ -22,7 +22,7 @@ env:
   AGENT_NAME: Roku
   AGENT_SLUG: roku
   AGENT_FILE_PREFIX: streaming-others-agent
-  AGENT_SUBJECT: Streaming Video & Ads for Others
+  AGENT_SUBJECT: Streaming Video & Ads for others
   # --- Shared docs config ---
   DOCS_FOLDER: src/content/docs/release-notes/streaming-others-release-notes
 


### PR DESCRIPTION
## Summary
- Changes `AGENT_SUBJECT` in `release-notes-docs-pr.yml` from `Streaming Video & Ads for Others` to `Streaming Video & Ads for others` (lowercase "others").

Per docs team suggestion in #vs-dev-internal — "others" appears to be a fixed lowercase taxonomy value on the docs site, unlike "Browser"/"Mobile" which are capitalized category names.