### PR TITLE
chore: derive docs MDX filename date from release date, not workflow-run date

### DIFF
--- a/.github/workflows/release-notes-docs-pr.yml
+++ b/.github/workflows/release-notes-docs-pr.yml
@@ -92,7 +92,11 @@ jobs:
           tag="${{ steps.release.outputs.tag }}"
           version="${tag#v}"
           releaseDate="${{ steps.release.outputs.releaseDate }}"
-          fileDate=$(date -u "+%y-%m-%d")
+          if [[ -n "${releaseDate}" ]]; then
+            fileDate="${releaseDate:2}"
+          else
+            fileDate=$(date -u "+%y-%m-%d")
+          fi
           releaseFile="${{ env.DOCS_FOLDER }}/${{ env.AGENT_FILE_PREFIX }}-${fileDate}.mdx"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "releaseFile=${releaseFile}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-notes-docs-pr.yml
+++ b/.github/workflows/release-notes-docs-pr.yml
@@ -22,7 +22,7 @@ env:
   AGENT_NAME: Roku
   AGENT_SLUG: roku
   AGENT_FILE_PREFIX: streaming-others-agent
-  AGENT_SUBJECT: Streaming Video & Ads for Others
+  AGENT_SUBJECT: Streaming Video & Ads for others
   # --- Shared docs config ---
   DOCS_FOLDER: src/content/docs/release-notes/streaming-others-release-notes
 


### PR DESCRIPTION
## Summary
- In `release-notes-docs-pr.yml`, `fileDate` (used to build the docs-website MDX filename) was always `date -u "+%y-%m-%d"` — today's date when the workflow runs — while `releaseDate` (used in the MDX frontmatter) is correctly extracted from `CHANGELOG.md`. This produced files like `..-videojs-26-08-11.mdx` whose frontmatter said `releaseDate: '2026-06-18'` — a mismatch flagged by the docs team on newrelic/docs-website#25219.
- `fileDate` now derives from `releaseDate` (stripping the century prefix, e.g. `2026-06-18` -> `26-06-18`), falling back to today's date only if `releaseDate` extraction fails.

Applies the same fix across all streaming-agent repos with this workflow.

## Test plan
- [ ] Run `release-notes-docs-pr.yml` with `dry_run: true` on an existing release tag and confirm the printed filename date matches the release date in CHANGELOG.md