### PR TITLE
docs: add harvest cycle configuration documentation

### DIFF
--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -130,8 +130,6 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | contentId                | The ID of the video.                                                                                          |
 | contentTitle             | The title of the video.                                                                                       |
 | contentBitrate           | The actual encoding bitrate of the currently playing rendition (in bits per second).                          |
-| contentSegmentDownloadBitrate | Bandwidth estimate used by the ABR (Adaptive Bitrate) algorithm (in bits per second).                   |
-| contentNetworkDownloadBitrate | Raw network download speed from the most recent segment (in bits per second).                           |
 | contentIsFullscreen      | Always "true".                                                                                                |
 | contentRenditionName     | Name of the rendition (e.g., 1080p).                                                                          |
 | contentDuration          | Duration of the video, in ms.                                                                                 |
@@ -140,7 +138,7 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | contentIsFullscreen      | True if the video is currently fullscreen.                                                                    |
 | contentIsMuted           | True if the video is currently muted.                                                                         |
 | totalAdPlaytime          | Total time ad is played for this video session.                                                               |
-| elapsedTime              | Time that has passed since the last event.                                                                    |
+| elapsedTime              | Active content watched between two consecutive heartbeats, in milliseconds.                                                                    |
 | bufferType               | When buffer starts, i.e., initial, seek, pause & connection.                                                  |
 | timestamp                | The time (date, hour, minute, second) at which the interaction occurred.                                      |
 | instrumentation.provider | Player/agent name.                                                                                            |
@@ -149,6 +147,9 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | enduser.id               | User ID.                                                                                                      |
 
 **QoE (Quality of Experience) Attributes** - These attributes are sent with `actionName = QOE_AGGREGATE` events:
+
+> **Note:** QoE aggregate events are opt-in and must be explicitly enabled. Reporting frequency is configurable per integration.
+
 
 | Attribute Name           | Definition                                                                                                                                         |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -210,7 +211,7 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | adCreativeId             | The creative ID of the ad.                                                                                              |
 | adPartner                | The ad partner, e.g., ima, freewheel.                                                                                   |
 | timestamp                | The time (date, hour, minute, second) at which the interaction occurred.                                                |
-| elapsedTime              | Time that has passed since the last event.                                                                              |
+| elapsedTime              | Active content watched between two consecutive heartbeats, in milliseconds.                                                                              |
 | instrumentation.provider | Player/agent name.                                                                                                      |
 | instrumentation.name     | Name of the instrumentation collecting the data.                                                                        |
 | instrumentation.version  | Agent’s version.                                                                                                        |
@@ -250,7 +251,7 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | errorCode                | Error code if it's known.                                                                                     |
 | backTrace                | Stack trace of the error.                                                                                     |
 | contentSrc               | Content source URL.                                                                                           |
-| elapsedTime              | Time that has passed since the last event.                                                                    |
+| elapsedTime              | Active content watched between two consecutive heartbeats, in milliseconds.                                                                    |
 | timestamp                | The time (date, hour, minute, second) at which the interaction occurred.                                      |
 | instrumentation.provider | Player/agent name.                                                                                            |
 | instrumentation.name     | Name of the instrumentation collecting the data.                                                              |

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -129,7 +129,9 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | viewId                   | Trackers will generate unique IDs for every new video iteration.                                              |
 | contentId                | The ID of the video.                                                                                          |
 | contentTitle             | The title of the video.                                                                                       |
-| contentBitrate           | The actual encoding bitrate of the currently playing rendition (in bits per second).                          |
+| contentBitrate                      | The actual encoding bitrate of the currently playing rendition (in bits per second).                          |
+| contentSegmentDownloadBitrate       | Measured bitrate (in bits per second) based on segment download performance.                                  |
+| contentNetworkDownloadBitrate       | Network download bitrate (in bits per second) measured during content delivery.                               |
 | contentIsFullscreen      | Always "true".                                                                                                |
 | contentRenditionName     | Name of the rendition (e.g., 1080p).                                                                          |
 | contentDuration          | Duration of the video, in ms.                                                                                 |
@@ -147,8 +149,6 @@ An Attribute is a piece of data associated with an event. Attributes provide add
 | enduser.id               | User ID.                                                                                                      |
 
 **QoE (Quality of Experience) Attributes** - These attributes are sent with `actionName = QOE_AGGREGATE` events:
-
-> **Note:** QoE aggregate events are opt-in and must be explicitly enabled. Reporting frequency is configurable per integration.
 
 
 | Attribute Name           | Definition                                                                                                                                         |

--- a/README.md
+++ b/README.md
@@ -559,6 +559,20 @@ nrForceHarvestLogs(m.nr)
 
 ---
 
+### Live Stream Configuration
+
+For live content, keep the harvest time at the minimum (60s) for timely data delivery:
+
+```brightscript
+' Live content — use minimum harvest time
+nrSetHarvestTime(nr, 60)
+
+' VOD content — higher values reduce network overhead
+nrSetHarvestTime(nr, 120)
+```
+
+---
+
 ### QoE Tracking
 
 Quality of Experience tracking is **enabled by default**. It sends `QOE_AGGREGATE` events containing startup time, rebuffering, bitrate, and error KPIs. The default interval multiplier is `2` (QoE evaluated every 2 harvest cycles).


### PR DESCRIPTION
Adds `### Live Stream Configuration` section to README.md.

Part of [PRD: Harvest Cycle Configuration Documentation](https://newrelic.atlassian.net/wiki/spaces/VERTSOL/pages/5952111079/PRD+Harvest+Cycle+Configuration+Documentation).