### PR TITLE
Fix: stop leaking errorCode/errorMessage onto non-error video events

### DIFF
--- a/components/NewRelicAgent/NRAgent.brs
+++ b/components/NewRelicAgent/NRAgent.brs
@@ -1623,11 +1623,13 @@ function nrSendBackupVideoEnd() as Void
 end function
 
 function nrAddVideoAttributes(ev as Object) as Object
-    ev.AddReplace("errorMessage",m.nrVideoObject.errorMsg)
-    ev.AddReplace("errorCode",m.nrVideoObject.errorCode)
-    if m.nrVideoObject.errorInfo <> invalid
-        ev.AddReplace("backtrace",m.nrVideoObject.errorInfo.source)
-    end if
+    ' errorCode/errorMessage/backtrace are intentionally NOT set here. This
+    ' helper runs for every VideoAction/VideoAdAction/VideoErrorAction event,
+    ' but the Video node's errorCode/errorMsg/errorInfo fields reflect the
+    ' last error seen (Roku defaults errorCode to 0, not invalid, when there
+    ' is no error). Stamping them here leaked errorCode=0 onto every
+    ' non-error event, including heartbeats (NR-606648). Error events set
+    ' these explicitly via nrSendError()/nrSendErrorEvent().
     ev.AddReplace("contentDuration", m.nrVideoObject.duration * 1000)
     ev.AddReplace("contentPlayhead", m.nrVideoObject.position * 1000)
     ev.AddReplace("contentIsMuted", m.nrVideoObject.mute)

--- a/source/tests/Test__Main.brs
+++ b/source/tests/Test__Main.brs
@@ -14,6 +14,7 @@ Function TestSuite__Main() as Object
     this.addTest("VideoEvents", TestCase__Main_VideoEvents)
     this.addTest("TimeSinceAttributes", TestCase__Main_TimeSinceAttributes)
     this.addTest("RAFTracker", TestCase__Main_RAFTracker)
+    this.addTest("NoErrorAttributesOnNonErrorEvents", TestCase__Main_NoErrorAttributesOnNonErrorEvents)
 
     return this
 End Function
@@ -190,5 +191,36 @@ Function TestCase__Main_RAFTracker() as String
         m.assertTrue(events[6].timeSinceAdStarted > 600 AND events[6].timeSinceAdStarted < 630)
         m.assertEqual(events[7].actionName, "AD_BREAK_END")
         m.assertTrue(events[7].timeSinceAdBreakBegin > 1400 AND events[7].timeSinceAdBreakBegin < 1500)
+    ])
+End Function
+
+' Regression test for NR-606648: the Video node's errorCode/errorMsg fields
+' (DummyVideo fakes a permanently non-zero errorCode, mirroring how Roku's
+' real Video node always reports errorCode=0 even when there is no error)
+' must only be attached to actual error events, not every VideoAction.
+Function TestCase__Main_NoErrorAttributesOnNonErrorEvents() as String
+    print "Checking error attributes are not leaked onto non-error events..."
+
+    Video_Tracking_SetUp(m)
+
+    m.videoObject.callFunc("startBuffering")
+    m.videoObject.callFunc("error")
+
+    events = m.nr.callFunc("nrExtractAllSamples", "event")
+
+    return multiAssert([
+        m.assertArrayCount(events, 4)
+        m.assertEqual(events[0].actionName, "CONTENT_REQUEST")
+        m.assertInvalid(events[0].errorCode)
+        m.assertInvalid(events[0].errorMessage)
+        m.assertEqual(events[1].actionName, "CONTENT_BUFFER_START")
+        m.assertInvalid(events[1].errorCode)
+        m.assertInvalid(events[1].errorMessage)
+        m.assertEqual(events[2].actionName, "CONTENT_BUFFER_END")
+        m.assertInvalid(events[2].errorCode)
+        m.assertInvalid(events[2].errorMessage)
+        m.assertEqual(events[3].actionName, "CONTENT_ERROR")
+        m.assertEqual(events[3].errorCode, 12345)
+        m.assertEqual(events[3].errorMessage, "whatever error")
     ])
 End Function


### PR DESCRIPTION
## Summary
- `nrAddVideoAttributes()` unconditionally copied the Video node's `errorCode`/`errorMsg`/`errorInfo` fields onto **every** `VideoAction`/`VideoAdAction`/`VideoErrorAction` event. Roku's `Video` node defaults `errorCode` to `0` (and `errorMsg` to `""`) when there is no error, so every heartbeat/start/pause/etc. event ended up reporting `errorCode: 0` with no message.
- `nrSendError()` already sets `errorMessage`/`errorCode`/`backtrace` explicitly for `CONTENT_ERROR`, and those are appended *after* `nrAddVideoAttributes` runs (overwriting it), so removing the leaking assignment doesn't change error-event payloads.
- Same fix as #140, cherry-picked onto `release/20JUL2026`.
- Fixes NR-606648, reported by a customer (Bell, Tegna) via Slack: https://newrelic.slack.com/archives/C0ATQLE2FQC/p1786720869919209

## Test plan
- [x] Added regression test `TestCase__Main_NoErrorAttributesOnNonErrorEvents` in `source/tests/Test__Main.brs`.
- [ ] Run the full BrightScript unit test suite on a physical/emulated Roku device (`./test.sh ROKU_IP`) before merge.

Jira: NR-606648

🤖 Generated with [Claude Code](https://claude.com/claude-code)