### PR TITLE
chore: host Roku S3 build artifact as video-agent-roku-latest.zip and versioned zip

### DIFF
--- a/.github/workflows/s3-upload.yml
+++ b/.github/workflows/s3-upload.yml
@@ -12,6 +12,8 @@ jobs:
     # Only run if PR was merged (not just closed)
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout code
@@ -82,6 +84,13 @@ jobs:
           echo ""
           echo "✓ Zip file validation passed"
 
+      - name: Read package version
+        id: version
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Package version: ${version}"
+
       - name: Upload artifact for publishing
         uses: actions/upload-artifact@v4
         with:
@@ -110,12 +119,20 @@ jobs:
 
       - name: Upload to S3
         run: |
-          echo "Uploading NewRelicAgent.zip to S3..."
+          version="${{ needs.build.outputs.version }}"
+          latestKey="media-agents/roku/video-agent-roku-latest.zip"
+          versionedKey="media-agents/roku/video-agent-roku-${version}.zip"
 
-          # Upload to S3
+          echo "Uploading video-agent-roku-latest.zip to S3..."
           aws s3 cp out/NewRelicAgent.zip \
-            s3://${{ secrets.S3_BUCKET_NAME }}/media-agents/roku/NewRelicAgent.zip \
+            "s3://${{ secrets.S3_BUCKET_NAME }}/${latestKey}" \
+            --content-type application/zip
+
+          echo "Uploading video-agent-roku-${version}.zip to S3..."
+          aws s3 cp out/NewRelicAgent.zip \
+            "s3://${{ secrets.S3_BUCKET_NAME }}/${versionedKey}" \
             --content-type application/zip
 
           echo "✓ Upload complete!"
-          echo "S3 Location: s3://${{ secrets.S3_BUCKET_NAME }}/media-agents/roku/NewRelicAgent.zip"
+          echo "S3 Location: s3://${{ secrets.S3_BUCKET_NAME }}/${latestKey}"
+          echo "S3 Location: s3://${{ secrets.S3_BUCKET_NAME }}/${versionedKey}"


### PR DESCRIPTION
## Summary
- The `s3-upload.yml` workflow previously uploaded every merged-PR build to a single fixed, unversioned key: `s3://<bucket>/media-agents/roku/NewRelicAgent.zip`.
- Now uploads the same build artifact to two well-known keys instead:
  - `media-agents/roku/video-agent-roku-latest.zip` — always the most recent build
  - `media-agents/roku/video-agent-roku-<version>.zip` — versioned, read from `package.json` (currently `4.2.2`)
- Added a `Read package version` step and a `build` job output so the `publish` job can read the version.

Jira: NR-607948

## Test plan
- [ ] Merge to `master` and confirm the workflow runs on the merge-triggered PR-closed event
- [ ] Verify both `video-agent-roku-latest.zip` and `video-agent-roku-<version>.zip` exist in S3 with correct content and `content-type: application/zip`
- [ ] Confirm no other platform builds/workflows are affected